### PR TITLE
[MRG] bubble map

### DIFF
--- a/notebooks/bubble-maps.md
+++ b/notebooks/bubble-maps.md
@@ -36,6 +36,33 @@ jupyter:
     v4upgrade: true
 ---
 
+### Bubble map with plotly express
+
+Plotly express functions take as argument a tidy [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/getting_started/10min.html). With ``px.scatter_geo``, each line of the dataframe is represented as a marker point. The column set as the `size` argument gives the size of markers.
+
+```python
+import plotly.express as px
+gapminder = px.data.gapminder().query("year==2007")
+fig = px.scatter_geo(gapminder, locations="iso_alpha", color="continent", 
+                     hover_name="country", size="pop",
+                     projection="natural earth")
+fig.show()
+```
+
+### Bubble Map with animation
+
+```python
+import plotly.express as px
+gapminder = px.data.gapminder()
+fig = px.scatter_geo(gapminder, locations="iso_alpha", color="continent", 
+                     hover_name="country", size="pop",
+                     animation_frame="year",
+                     projection="natural earth")
+fig.show()
+```
+
+### Bubble Map with go.Scattergeo
+
 #### United States Bubble Map
 
 Note about `sizeref`:


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
