### PR TITLE
Theming chapter

### DIFF
--- a/notebooks/templates.md
+++ b/notebooks/templates.md
@@ -87,6 +87,8 @@ If a theme is not provided to a plotly express function or to a graph object fig
 
 Here is an example of changing to default theme to `"plotly_white"` and then constructing a scatter plot with plotly express without providing a template.
 
+> Note: Default themes persist for the duration of a single session, but they do not persist across sessions. If you are working in an IPython kernel, this means that default themes will persist for the life of the kernel, but they will not persist across kernel restarts.
+
 ```python
 import plotly.io as pio
 import plotly.express as px


### PR DESCRIPTION
Here is the initial draft of the theming chapter for the v4 docs.

cc @nicolaskruchten @emmanuelle @chriddyp 

Closes https://github.com/plotly/plotly.py-docs/issues/7

---
Doc upgrade checklist:
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
