### PR TITLE
splom notebook

### DIFF
--- a/notebooks/splom.md
+++ b/notebooks/splom.md
@@ -79,9 +79,9 @@ fig.show()
 ```
 
 <!-- #region -->
-### Scatter matrix (plom) with go.Splom
+### Scatter matrix (splom) with go.Splom
 
-When data are not available as a tidy dataframe, it is possible to use the more generic `go.Splom` function. **WHere is its API documentation??**
+When data are not available as a tidy dataframe, it is possible to use the more generic `go.Splom` function. All its parameters are documented in the reference page https://plot.ly/python/reference/#splom.
 
 The Plotly splom trace implementation for the scatterplot matrix does not require to set  $x=Xi$ , and  $y=Xj$, for each scatter plot. All arrays, $X_1,X_2,…,X_n$ , are passed once, through a list of dicts called dimensions, i.e. each array/variable represents a dimension.
 


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
