### PR TITLE
error bars notebook

### DIFF
--- a/notebooks/error-bars.md
+++ b/notebooks/error-bars.md
@@ -8,9 +8,19 @@ jupyter:
       format_version: '1.1'
       jupytext_version: 1.1.1
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.7
   plotly:
     description: How to add error-bars to charts in Python with Plotly.
     display_as: statistical
@@ -24,156 +34,152 @@ jupyter:
     permalink: python/error-bars/
     thumbnail: thumbnail/error-bar.jpg
     title: Error Bars | plotly
+    v4upgrade: true
 ---
 
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
+### Error Bars with plotly express
 
+Plotly express functions take as argument a tidy [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/getting_started/10min.html). For functions representing 2D data points such as [`px.scatter`](https://plot.ly/python/line-and-scatter/), [`px.line`](https://plot.ly/python/line-charts/), [`px.bar`](https://plot.ly/python/bar-charts/) etc., error bars are given as a column name which is the value of the `error_x` (for the error on x position) and `error_y` (for the error on y position). 
+
+```python
+import plotly.express as px
+iris = px.data.iris()
+iris["e"] = iris["sepal_width"]/100
+fig = px.scatter(iris, x="sepal_width", y="sepal_length", color="species", 
+                 error_x="e", error_y="e")
+fig.show()
+```
+
+#### Asymmetric Error Bars with plotly express
+
+```python
+import plotly.express as px
+iris = px.data.iris()
+iris["e_plus"] = iris["sepal_width"]/100
+iris["e_minus"] = iris["sepal_width"]/40
+fig = px.scatter(iris, x="sepal_width", y="sepal_length", color="species", 
+                 error_y="e_plus", error_y_minus="e_minus")
+fig.show()
+```
+
+### Error Bars with graph_objects
 
 #### Basic Symmetric Error Bars
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
-    go.Scatter(
+fig = go.Figure(data=go.Scatter(
         x=[0, 1, 2],
         y=[6, 10, 2],
         error_y=dict(
-            type='data',
+            type='data', # value of error bar given in data coordinates
             array=[1, 2, 3],
-            visible=True
-        )
-    )
-]
-
-py.iplot(data, filename='basic-error-bar')
+            visible=True)
+    ))
+fig.show()
 ```
 
 #### Asymmetric Error Bars
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
-    go.Scatter(
+fig = go.Figure(data=go.Scatter(
         x=[1, 2, 3, 4],
         y=[2, 1, 3, 4],
         error_y=dict(
             type='data',
             symmetric=False,
             array=[0.1, 0.2, 0.1, 0.1],
-            arrayminus=[0.2, 0.4, 1, 0.2]
-        )
-    )
-]
-py.iplot(data, filename='error-bar-asymmetric-array')
+            arrayminus=[0.2, 0.4, 1, 0.2])
+        ))
+fig.show()
 ```
 
 #### Error Bars as a Percentage of the y Value
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
-    go.Scatter(
+fig = go.Figure(data=go.Scatter(
         x=[0, 1, 2],
         y=[6, 10, 2],
         error_y=dict(
-            type='percent',
+            type='percent', # value of error bar given as percentage of y value
             value=50,
-            visible=True
-        )
-    )
-]
-py.iplot(data, filename='percent-error-bar')
+            visible=True)
+    ))
+fig.show()
 ```
 
 #### Asymmetric Error Bars with a Constant Offset
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
-    go.Scatter(
+fig = go.Figure(data=go.Scatter(
         x=[1, 2, 3, 4],
         y=[2, 1, 3, 4],
         error_y=dict(
             type='percent',
             symmetric=False,
             value=15,
-            valueminus=25
-        )
-    )
-]
-py.iplot(data, filename='error-bar-asymmetric-constant')
+            valueminus=25)
+    ))
+fig.show()
 ```
 
 #### Horizontal Error Bars
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
-    go.Scatter(
+fig = go.Figure(data=go.Scatter(
         x=[1, 2, 3, 4],
         y=[2, 1, 3, 4],
         error_x=dict(
             type='percent',
-            value=10
-        )
-    )
-]
-py.iplot(data, filename='error-bar-horizontal')
+            value=10)
+    ))
+fig.show()
 ```
 
 #### Bar Chart with Error Bars
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-trace1 = go.Bar(
+fig = go.Figure()
+fig.add_trace(go.Bar(
     x=['Trial 1', 'Trial 2', 'Trial 3'],
     y=[3, 6, 4],
     name='Control',
     error_y=dict(
         type='data',
         array=[1, 0.5, 1.5],
-        visible=True
-    )
-)
-trace2 = go.Bar(
+        visible=True,
+        color='white')
+))
+fig.add_trace(go.Bar(
     x=['Trial 1', 'Trial 2', 'Trial 3'],
     y=[4, 7, 3],
     name='Experimental',
     error_y=dict(
         type='data',
         array=[0.5, 1, 2],
-        visible=True
+        visible=True,
+        color='white'
     )
-)
-data = [trace1, trace2]
-layout = go.Layout(
-    barmode='group'
-)
-fig = go.Figure(data=data, layout=layout)
-py.iplot(fig, filename='error-bar-bar')
+))
+fig.update_layout(barmode='group')
+fig.show()
 ```
 
 #### Colored and Styled Error Bars
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
-
+import plotly.graph_objects as go
 import numpy as np
 
 x_theo = np.linspace(-4, 4, 100)
@@ -181,60 +187,34 @@ sincx = np.sinc(x_theo)
 x = [-3.8, -3.03, -1.91, -1.46, -0.89, -0.24, -0.0, 0.41, 0.89, 1.01, 1.91, 2.28, 2.79, 3.56]
 y = [-0.02, 0.04, -0.01, -0.27, 0.36, 0.75, 1.03, 0.65, 0.28, 0.02, -0.11, 0.16, 0.04, -0.15]
 
-trace1 = go.Scatter(
-    x=x_theo,
-    y=sincx,
+fig = go.Figure()
+fig.add_trace(go.Scatter(
+    x=x_theo, y=sincx,
     name='sinc(x)'
-)
-trace2 = go.Scatter(
-    x=x,
-    y=y,
+))
+fig.add_trace(go.Scatter(
+    x=x, y=y,
     mode='markers',
     name='measured',
     error_y=dict(
         type='constant',
         value=0.1,
-        color='#85144B',
+        color='purple',
         thickness=1.5,
         width=3,
     ),
     error_x=dict(
         type='constant',
         value=0.2,
-        color='#85144B',
+        color='purple',
         thickness=1.5,
         width=3,
     ),
-    marker=dict(
-        color='#85144B',
-        size=8
-    )
-)
-data = [trace1, trace2]
-py.iplot(data, filename='error-bar-style')
+    marker=dict(color='purple', size=8)
+))
+fig.show()
 ```
 
 #### Reference
 See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
 
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'error-bars.ipynb', 'python/error-bars/', 'Error Bars | plotly',
-    'How to add error-bars to charts in Python with Plotly.',
-    title = 'Error Bars | plotly',
-    name = 'Error Bars',
-    thumbnail='thumbnail/error-bar.jpg', language='python',
-    page_type='example_index', has_thumbnail='true', display_as='statistical', order=1,
-    ipynb='~notebook_demo/18')
-```
-
-```python
-
-```


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
