### PR TITLE
parallel coordinates

### DIFF
--- a/notebooks/parallel-coordinates-plot.md
+++ b/notebooks/parallel-coordinates-plot.md
@@ -41,7 +41,7 @@ jupyter:
 
 ## Parallel Coordinates plot with plotly express
 
-Plotly express functions take as argument a tidy [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/getting_started/10min.html). In a parallel coordinates plot with `px.parallel_coordinates`, each row of the DataFrame is represented by a polyline mark which traverses a set of parallel axes, one for each of the dimensions. For other representations of multivariate data, also see [radar charts](../radar-chart/).
+Plotly express functions take as argument a tidy [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/getting_started/10min.html). In a parallel coordinates plot with `px.parallel_coordinates`, each row of the DataFrame is represented by a polyline mark which traverses a set of parallel axes, one for each of the dimensions. For other representations of multivariate data, also see [radar charts](../radar-chart/) and [scatterplot matrix (SPLOM)](../splom/).
 
 ```python
 import plotly.express as px


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
