### PR TITLE
dendrogram

### DIFF
--- a/notebooks/dendrogram.md
+++ b/notebooks/dendrogram.md
@@ -11,6 +11,16 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.7
   plotly:
     description: How to make a dendrogram in Python with Plotly.
     display_as: scientific
@@ -24,69 +34,58 @@ jupyter:
     permalink: python/dendrogram/
     thumbnail: thumbnail/dendrogram.jpg
     title: Dendrograms | Plotly
+    v4upgrade: true
 ---
 
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-#### Version Check
-Note: Dendrograms are available in version 1.8.7+.
-Run `pip install plotly --upgrade` to update your Plotly version.
+#### Basic Dendrogram
+
+A [dendrogram](https://en.wikipedia.org/wiki/Dendrogram) is a diagram representing a tree. The figure factory `create_dendrogram` performs [hierachical clustering](https://en.wikipedia.org/wiki/Hierarchical_clustering) on data and represents the resulting tree. Values on the tree depth axis correspond to distances between clusters.
+
+Dendrogram plots are commonly used in computational biology to show the clustering of genes or samples, sometimes in the margin of heatmaps.
 
 ```python
-import plotly
-plotly.__version__
+import plotly.figure_factory as ff
+import numpy as np
+
+X = np.random.rand(15, 12) # 15 samples, with 12 dimensions each
+fig = ff.create_dendrogram(X)
+fig.update_layout(width=800, height=500)
+fig.show()
 ```
 
-##### Basic Dendrogram
+#### Set Color Threshold
 
 ```python
-import plotly.plotly as py
 import plotly.figure_factory as ff
 
 import numpy as np
 
-X = np.random.rand(15, 15)
-dendro = ff.create_dendrogram(X)
-dendro['layout'].update({'width':800, 'height':500})
-py.iplot(dendro, filename='simple_dendrogram')
+X = np.random.rand(15, 10) # 15 samples, with 10 dimensions each
+fig = ff.create_dendrogram(X, color_threshold=1.5)
+fig.update_layout(width=800, height=500)
+fig.show()
 ```
 
-##### Set Color Threshold
+#### Set Orientation and Add Labels
 
 ```python
-import plotly.plotly as py
 import plotly.figure_factory as ff
 
 import numpy as np
 
-X = np.random.rand(15, 15)
-dendro = ff.create_dendrogram(X, color_threshold=1.5)
-dendro['layout'].update({'width':800, 'height':500})
-py.iplot(dendro, filename='simple_dendrogram_with_color_threshold')
-```
-
-##### Set Orientation and Add Labels
-
-```python
-import plotly.plotly as py
-import plotly.figure_factory as ff
-
-import numpy as np
-
-X = np.random.rand(10, 10)
+X = np.random.rand(10, 12)
 names = ['Jack', 'Oxana', 'John', 'Chelsea', 'Mark', 'Alice', 'Charlie', 'Rob', 'Lisa', 'Lily']
 fig = ff.create_dendrogram(X, orientation='left', labels=names)
-fig['layout'].update({'width':800, 'height':800})
-py.iplot(fig, filename='dendrogram_with_labels')
+fig.update_layout(width=800, height=800)
+fig.show()
 ```
 
-##### Plot a Dendrogram with a Heatmap
+#### Plot a Dendrogram with a Heatmap
+
+See also the [Dash Bio demo](https://dash-bio.plotly.host/dash-clustergram/).
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 import plotly.figure_factory as ff
 
 import numpy as np
@@ -101,9 +100,9 @@ data_array = data_array.transpose()
 labels = data.dtype.names
 
 # Initialize figure by creating upper dendrogram
-figure = ff.create_dendrogram(data_array, orientation='bottom', labels=labels)
-for i in range(len(figure['data'])):
-    figure['data'][i]['yaxis'] = 'y2'
+fig = ff.create_dendrogram(data_array, orientation='bottom', labels=labels)
+for i in range(len(fig['data'])):
+    fig['data'][i]['yaxis'] = 'y2'
 
 # Create Side Dendrogram
 dendro_side = ff.create_dendrogram(data_array, orientation='right')
@@ -112,7 +111,7 @@ for i in range(len(dendro_side['data'])):
 
 # Add Side Dendrogram Data to Figure
 for data in dendro_side['data']:
-    figure.add_trace(data)
+    fig.add_trace(data)
 
 # Create Heatmap
 dendro_leaves = dendro_side['layout']['yaxis']['ticktext']
@@ -131,82 +130,57 @@ heatmap = [
     )
 ]
 
-heatmap[0]['x'] = figure['layout']['xaxis']['tickvals']
+heatmap[0]['x'] = fig['layout']['xaxis']['tickvals']
 heatmap[0]['y'] = dendro_side['layout']['yaxis']['tickvals']
 
 # Add Heatmap Data to Figure
 for data in heatmap:
-    figure.add_trace(data)
+    fig.add_trace(data)
 
 # Edit Layout
-figure['layout'].update({'width':800, 'height':800,
+fig.update_layout({'width':800, 'height':800,
                          'showlegend':False, 'hovermode': 'closest',
                          })
 # Edit xaxis
-figure['layout']['xaxis'].update({'domain': [.15, 1],
+fig.update_layout(xaxis={'domain': [.15, 1],
                                   'mirror': False,
                                   'showgrid': False,
                                   'showline': False,
                                   'zeroline': False,
                                   'ticks':""})
 # Edit xaxis2
-figure['layout'].update({'xaxis2': {'domain': [0, .15],
+fig.update_layout(xaxis2={'domain': [0, .15],
                                    'mirror': False,
                                    'showgrid': False,
                                    'showline': False,
                                    'zeroline': False,
                                    'showticklabels': False,
-                                   'ticks':""}})
+                                   'ticks':""})
 
 # Edit yaxis
-figure['layout']['yaxis'].update({'domain': [0, .85],
+fig.update_layout(yaxis={'domain': [0, .85],
                                   'mirror': False,
                                   'showgrid': False,
                                   'showline': False,
                                   'zeroline': False,
                                   'showticklabels': False,
-                                  'ticks': ""})
+                                  'ticks': ""
+                        })
 # Edit yaxis2
-figure['layout'].update({'yaxis2':{'domain':[.825, .975],
+fig.update_layout(yaxis2={'domain':[.825, .975],
                                    'mirror': False,
                                    'showgrid': False,
                                    'showline': False,
                                    'zeroline': False,
                                    'showticklabels': False,
-                                   'ticks':""}})
+                                   'ticks':""})
 
 # Plot!
-py.iplot(figure, filename='dendrogram_with_heatmap')
-```
-
-```python
-dendro_side['layout']['xaxis']
+fig.show()
 ```
 
 ### Reference
 
 ```python
 help(ff.create_dendrogram)
-```
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'dendrograms.ipynb', 'python/dendrogram/', 'Python Dendrograms',
-    'How to make a dendrogram in Python with Plotly. ',
-    name = 'Dendrograms',
-    title = "Dendrograms | Plotly",
-    thumbnail='thumbnail/dendrogram.jpg', language='python',
-    has_thumbnail='true', display_as='scientific', order=6,
-    ipynb= '~notebook_demo/262')
-```
-
-```python
-
 ```


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
