### PR TITLE
Scatter map

### DIFF
--- a/notebooks/scatter-plots-on-maps.md
+++ b/notebooks/scatter-plots-on-maps.md
@@ -38,7 +38,35 @@ jupyter:
     v4upgrade: true
 ---
 
+### Geographical Scatter Plot with px.scatter_geo
+
+For data available as a tidy pandas DataFrame, use `px.scatter_geo` for a geographical scatter plot. The `size` argument is used to set the size of markers from a given column of the DataFrame.
+
+```python
+import plotly.express as px
+gapminder = px.data.gapminder().query("year == 2007")
+fig = px.scatter_geo(gapminder, locations="iso_alpha",
+                     size="pop", # size of markers, "pop" is one of the columns of gapminder
+                     )
+fig.show()
+```
+
+#### Customize geographical scatter plot
+
+```python
+import plotly.express as px
+gapminder = px.data.gapminder().query("year == 2007")
+fig = px.scatter_geo(gapminder, locations="iso_alpha", 
+                     color="continent", # which column to use to set the color of markers 
+                     hover_name="country", # column added to hover information
+                     size="pop", # size of markers
+                     projection="natural earth")
+fig.show()
+```
+
 ### U.S. Airports Map
+
+Here we show how to use `go.Scattergeo` from `plotly.graph_objects`.
 
 #### Simple U.S. Airports Map
 


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
