### PR TITLE
Rename user guide back to creating and updating figures

### DIFF
--- a/notebooks/creating-and-updating-figures.md
+++ b/notebooks/creating-and-updating-figures.md
@@ -22,15 +22,15 @@ jupyter:
     pygments_lexer: ipython3
     version: 3.7.3
 plotly:
-    description: Plotly User Guide for Python
+    description: Creating and Updating Figures from Python
     has_thumbnail: false
     language: python
     layout: user-guide
     name: Plotly User Guide
     page_type: u-guide
-    permalink: python/user-guide/
+    permalink: python/creating-updating-figures/
     thumbnail: null
-    title: Plotly User Guide for Python
+    title: Creating and Updating Figures
     v4upgrade: true
 ---
 


### PR DESCRIPTION
This PR gives the "Creating and Updating Figures" page it's own permalink (python/creating-updating-figures/), rather than calling it the user guide.  The plan is to redirect the user guide to this page for now, but once we have a replacement user guide, we'd like this page to have a stable URL.

@nicolaskruchten 