### PR TITLE
figure-labels

### DIFF
--- a/notebooks/figure-labels.md
+++ b/notebooks/figure-labels.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.6
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.7.3
   plotly:
     description: How to set the title, legend-entries, and axis-titles in python.
     display_as: layout_opt
@@ -25,101 +35,58 @@ jupyter:
     thumbnail: thumbnail/labels.jpg
     title: Setting the Title, Legend Entries, and Axis Titles in Python | Examples
       | Plotly
+    v4upgrade: true
 ---
 
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-#### Version Check
-Plotly's Python API is updated frequently. Run pip install plotly --upgrade to update your Plotly version.
-
 ```python
-import plotly
-plotly.__version__
-```
+import plotly.graph_objects as go
 
-```python
-import plotly.plotly as py
-import plotly.graph_objs as go
 
-trace1 = go.Scatter(
+fig = go.Figure()
+
+fig.add_trace(go.Scatter(
     x=[0, 1, 2, 3, 4, 5, 6, 7, 8],
     y=[0, 1, 2, 3, 4, 5, 6, 7, 8],
-    name='Name of Trace 1'
-)
-trace2 = go.Scatter(
+    name="Name of Trace 1"
+))
+
+
+fig.add_trace(go.Scatter(
     x=[0, 1, 2, 3, 4, 5, 6, 7, 8],
     y=[1, 0, 3, 2, 5, 4, 7, 6, 8],
-    name='Name of Trace 2'
-)
-data = [trace1, trace2]
-layout = go.Layout(
+    name="Name of Trace 2"
+))
+
+fig.update_layout(
     title=go.layout.Title(
-        text='Plot Title',
-        xref='paper',
+        text="Plot Title",
+        xref="paper",
         x=0
     ),
     xaxis=go.layout.XAxis(
         title=go.layout.xaxis.Title(
-            text='x Axis',
+            text="x Axis",
             font=dict(
-                family='Courier New, monospace',
+                family="Courier New, monospace",
                 size=18,
-                color='#7f7f7f'
+                color="#7f7f7f"
             )
         )
     ),
     yaxis=go.layout.YAxis(
         title=go.layout.yaxis.Title(
-            text='y Axis',
+            text="y Axis",
             font=dict(
-                family='Courier New, monospace',
+                family="Courier New, monospace",
                 size=18,
-                color='#7f7f7f'
+                color="#7f7f7f"
             )
         )
     )
 )
-fig = go.Figure(data=data, layout=layout)
-py.iplot(fig, filename='styling-names')
-```
 
-#### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-figurelabelsplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-figurelabelsplot/", width="100%", height="650px", frameBorder="0")
-
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-figurelabelsplot/code", width="100%", height="500px", frameBorder="0")
+fig.show()
 ```
 
 #### Reference
 See https://plot.ly/python/reference/#layout for more information!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'labels.ipynb', 'python/figure-labels/', 'Setting the Title, Legend Entries, and Axis Titles in Python | Examples | Plotly',
-    'How to set the title, legend-entries, and axis-titles in python.',
-    title = 'Setting the Title, Legend Entries, and Axis Titles in Python | Examples | Plotly',
-    name = 'Setting the Title, Legend Entries, and Axis Titles',
-    thumbnail='thumbnail/labels.jpg', language='python',
-    page_type='example_index', has_thumbnail='false', display_as='layout_opt', order=0.5,
-    ipynb='~notebook_demo/271')
-```


### PR DESCRIPTION
Minimal update to figure-labels section

Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
