### PR TITLE
update setting-graph-size

### DIFF
--- a/notebooks/setting-graph-size.md
+++ b/notebooks/setting-graph-size.md
@@ -107,10 +107,11 @@ fig.update_layout(
         ticktext=["Very long label", "long label", "3", "label"],
         tickvals=[1, 2, 3, 4],
         tickmode="array",
-        automargin=True,
         titlefont=dict(size=30),
     )
 )
+
+fig.update_yaxes(automargin=True)
 
 fig.show()
 ```


### PR DESCRIPTION
update setting-graph-size notebook

Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
