### PR TITLE
Update hover-text-and-formatting notebook

### DIFF
--- a/notebooks/hover-text-and-formatting.md
+++ b/notebooks/hover-text-and-formatting.md
@@ -37,6 +37,22 @@ jupyter:
     v4upgrade: true
 ---
 
+#### Hover text with plotly express
+Many plotly express functions support configurable hover text. The `hover_data` argument accepts a list of column names to be added to the hover tooltip. The `hover_name` property controls which column is displayed in bold as the tooltip title.
+
+Here is an example that creates a scatter plot using plotly express with custom hover data and a custom hover name.
+
+```python
+import plotly.express as px
+
+gapminder_2007 = px.data.gapminder().query("year==2007")
+
+fig = px.scatter(gapminder_2007, x="gdpPercap", y="lifeExp", log_x=True,
+                 hover_name="country", hover_data=["continent"])
+
+fig.show()
+```
+
 #### Add Hover Text
 
 ```python


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
