### PR TITLE
multiple-axes

### DIFF
--- a/notebooks/multiple-axes.md
+++ b/notebooks/multiple-axes.md
@@ -229,4 +229,4 @@ fig.show()
 ```
 
 #### Reference
-All of the y-axis properties are found here: https://plot.ly/python/reference/#YAxis
+All of the y-axis properties are found here: https://plot.ly/python/reference/#YAxis.  For more information on creating subplots see the [Subplots in Python](../subplots/) section.


### PR DESCRIPTION
This PR updates the multiple-axes notebook.  Two of the examples have been ported to use `make_subplots`.  The example of creating a plot with 4 y-axes pushed down to the end as a low-level example.

Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
