### PR TITLE
lines on maps notebook

### DIFF
--- a/notebooks/lines-on-maps.md
+++ b/notebooks/lines-on-maps.md
@@ -39,6 +39,21 @@ jupyter:
 
 For other geographical and map charts see [the maps index page](../maps/).
 
+Below we show how to create geographical line plots using either plotly express with `px.line_geo` (for data available as tidy pandas DataFrame) or `go.Scattergeo` for the generic case.
+
+## Lines on Maps with plotly express
+
+```python
+import plotly.express as px
+gapminder = px.data.gapminder().query("year == 2007")
+fig = px.line_geo(gapminder, locations="iso_alpha", 
+                  color="continent", # "continent" is one of the columns of gapminder 
+                  projection="orthographic")
+fig.show()
+```
+
+## Lines on Maps with plotly.graph_objects
+
 ### US Flight Paths Map
 
 ```python


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
