### PR TITLE
treemap notebook

### DIFF
--- a/notebooks/treemaps.md
+++ b/notebooks/treemaps.md
@@ -8,9 +8,19 @@ jupyter:
       format_version: '1.1'
       jupytext_version: 1.1.1
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.7
   plotly:
     description: How to make interactive treemap in Python with Plotly and Squarify.
       An examples of a treemap in Plotly using Squarify.
@@ -25,26 +35,19 @@ jupyter:
     permalink: python/treemaps/
     thumbnail: thumbnail/treemap.jpg
     title: Python Treemaps | plotly
+    v4upgrade: true
 ---
-
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-#### Version Check
-Plotly's python API is updated frequently. To upgrade, run `pip install plotly --upgrade`.
-
 
 #### Simple Example with Plotly and [Squarify](https://pypi.python.org/pypi/squarify)
 Define the coordinate system for the returned rectangles: these values will range from x to x + width and y to y + height.
 Then define your treemap values. The sum of the treemap values must equal the total area to be laid out (i.e. width `*` height). The values must be sorted in descending order and must be positive.
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
 import squarify
+
+fig = go.Figure()
 
 x = 0.
 y = 0.
@@ -63,7 +66,7 @@ shapes = []
 annotations = []
 counter = 0
 
-for r in rects:
+for r, val, color in zip(rects, values, color_brewer):
     shapes.append(
         dict(
             type = 'rect',
@@ -72,30 +75,27 @@ for r in rects:
             x1 = r['x']+r['dx'],
             y1 = r['y']+r['dy'],
             line = dict( width = 2 ),
-            fillcolor = color_brewer[counter]
+            fillcolor = color
         )
     )
     annotations.append(
         dict(
             x = r['x']+(r['dx']/2),
             y = r['y']+(r['dy']/2),
-            text = values[counter],
+            text = val,
             showarrow = False
         )
     )
-    counter = counter + 1
-    if counter >= len(color_brewer):
-        counter = 0
 
 # For hover text
-trace0 = go.Scatter(
+fig.add_trace(go.Scatter(
     x = [ r['x']+(r['dx']/2) for r in rects ],
     y = [ r['y']+(r['dy']/2) for r in rects ],
     text = [ str(v) for v in values ],
     mode = 'text',
-)
+))
 
-layout = dict(
+fig.update_layout(
     height=700,
     width=700,
     xaxis=dict(showgrid=False,zeroline=False),
@@ -105,37 +105,8 @@ layout = dict(
     hovermode='closest'
 )
 
-# With hovertext
-figure = dict(data=[trace0], layout=layout)
-
-# Without hovertext
-# figure = dict(data=[Scatter()], layout=layout)
-
-py.iplot(figure, filename='squarify-treemap')
+fig.show()
 ```
 
 #### Reference
 See https://plot.ly/python/reference/ for more information and chart attribute options or https://pypi.python.org/pypi/squarify for more information about squarify!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'treemap.ipynb', 'python/treemaps/', 'Python Treemaps | plotly',
-    'How to make interactive treemap in Python with Plotly and Squarify. '
-    'An examples of a treemap in Plotly using Squarify.',
-    title = 'Python Treemaps | plotly',
-    name = 'Treemaps',
-    thumbnail='thumbnail/treemap.jpg', language='python',
-    has_thumbnail='true', display_as='statistical', order=11,
-    ipynb= '~notebook_demo/29')
-```
-
-```python
-
-```


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
