### PR TITLE
Updated the images notebook

### DIFF
--- a/notebooks/images.md
+++ b/notebooks/images.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.7
   kernelspec:
     display_name: Python 3
     language: python
     name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.5
   plotly:
     description: How to add images to charts as background images or logos.
     display_as: style_opt
@@ -24,364 +34,276 @@ jupyter:
     permalink: python/images/
     thumbnail: thumbnail/your-tutorial-chart.jpg
     title: Layout with images | plotly
+    v4upgrade: true
 ---
-
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
 
 #### Add a Background Image
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-import numpy as np
-trace1= go.Scatter(x=[0,0.5,1,2,2.2],y=[1.23,2.5,0.42,3,1])
-layout= go.Layout(images= [dict(
-                  source= "https://images.plot.ly/language-icons/api-home/python-logo.png",
-                  xref= "x",
-                  yref= "y",
-                  x= 0,
-                  y= 3,
-                  sizex= 2,
-                  sizey= 2,
-                  sizing= "stretch",
-                  opacity= 0.5,
-                  layer= "below")])
-fig=go.Figure(data=[trace1],layout=layout)
-py.iplot(fig,filename='EXAMPLES/background')
+# Create figure
+fig = go.Figure()
+
+# Add trace
+fig.add_trace(
+    go.Scatter(x=[0, 0.5, 1, 2, 2.2], y=[1.23, 2.5, 0.42, 3, 1])
+)
+
+# Add images
+fig.update_layout(
+    images=[
+        go.layout.Image(
+            source="https://images.plot.ly/language-icons/api-home/python-logo.png",
+            xref="x",
+            yref="y",
+            x=0,
+            y=3,
+            sizex=2,
+            sizey=2,
+            sizing="stretch",
+            opacity=0.5,
+            layer="below")
+    ]
+)
+
+# Set templates
+fig.update_layout(template="plotly_white")
+
+fig.show()
 ```
 
 #### Add a Logo
 See more examples of [adding logos to charts](https://plot.ly/python/logos/)!
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-data = [
+fig = go.Figure()
+
+fig.add_trace(
     go.Bar(
-        x=['-35.3', '-15.9', '-15.8', '-15.6', '-11.1',
-           '-9.6', '-9.2', '-3.5', '-1.9', '-0.9',
-           '1.0', '1.4', '1.7', '2.0', '2.8', '6.2',
-           '8.1', '8.5', '8.5', '8.6', '11.4', '12.5',
-           '13.3', '13.7', '14.4', '17.5', '17.7',
-           '18.9', '25.1', '28.9', '41.4'],
-        y=['Designers, musicians, artists, etc.',
-           'Secretaries and administrative assistants',
-           'Waiters and servers', 'Archivists, curators, and librarians',
-           'Sales and related', 'Childcare workers, home car workers, etc.',
-           'Food preparation occupations', 'Janitors, maids, etc.',
-           'Healthcare technicians, assistants. and aides',
-           'Counselors, social and religious workers',
-           'Physical, life and social scientists', 'Construction',
-           'Factory assembly workers', 'Machinists, repairmen, etc.',
-           'Media and communications workers', 'Teachers',
-           'Mechanics, repairmen, etc.', 'Financial analysts and advisers',
-           'Farming, fishing and forestry workers',
-           'Truck drivers, heavy equipment operator, etc.','Accountants and auditors',
-           'Human resources, management analysts, etc.', 'Managers',
-           'Lawyers and judges', 'Engineers, architects and surveyors',
-           'Nurses', 'Legal support workers',
-           'Computer programmers and system admin.', 'Police officers and firefighters',
-           'Chief executives', 'Doctors, dentists and surgeons'],
-        marker=dict(
-            color='rgb(253, 240, 54)',
-            line=dict(color='rgb(0, 0, 0)',
+        x=["-35.3", "-15.9", "-15.8", "-15.6", "-11.1",
+           "-9.6", "-9.2", "-3.5", "-1.9", "-0.9",
+           "1.0", "1.4", "1.7", "2.0", "2.8", "6.2",
+           "8.1", "8.5", "8.5", "8.6", "11.4", "12.5",
+           "13.3", "13.7", "14.4", "17.5", "17.7",
+           "18.9", "25.1", "28.9", "41.4"],
+        y=["Designers, musicians, artists, etc.",
+           "Secretaries and administrative assistants",
+           "Waiters and servers", "Archivists, curators, and librarians",
+           "Sales and related", "Childcare workers, home car workers, etc.",
+           "Food preparation occupations", "Janitors, maids, etc.",
+           "Healthcare technicians, assistants. and aides",
+           "Counselors, social and religious workers",
+           "Physical, life and social scientists", "Construction",
+           "Factory assembly workers", "Machinists, repairmen, etc.",
+           "Media and communications workers", "Teachers",
+           "Mechanics, repairmen, etc.", "Financial analysts and advisers",
+           "Farming, fishing and forestry workers",
+           "Truck drivers, heavy equipment operator, etc.", "Accountants and auditors",
+           "Human resources, management analysts, etc.", "Managers",
+           "Lawyers and judges", "Engineers, architects and surveyors",
+           "Nurses", "Legal support workers",
+           "Computer programmers and system admin.", "Police officers and firefighters",
+           "Chief executives", "Doctors, dentists and surgeons"],
+        marker=go.bar.Marker(
+            color="rgb(253, 240, 54)",
+            line=dict(color="rgb(0, 0, 0)",
                       width=2)
         ),
-        orientation='h',
+        orientation="h",
     )
-]
+)
 
-layout = go.Layout(
+# Add image
+fig.update_layout(
     images=[dict(
         source="https://raw.githubusercontent.com/cldougl/plot_images/add_r_img/vox.png",
         xref="paper", yref="paper",
         x=1, y=1.05,
         sizex=0.2, sizey=0.2,
         xanchor="right", yanchor="bottom"
-      )],
-    autosize=False, height=800, width=700,
-    bargap=0.15, bargroupgap=0.1,
-    barmode='stack', hovermode='x',
-    margin=dict(r=20, l=300,
-                  b=75, t=125),
-    title='Moving Up, Moving Down<br><i>Percentile change in income between childhood and adulthood</i>',
-    xaxis=dict(
-        dtick=10, nticks=0,
-        gridcolor='rgba(102, 102, 102, 0.4)',
-        linecolor='#000', linewidth=1,
-        mirror=True,
-        showticklabels=True, tick0=0, tickwidth=1,
-        title='<i>Change in percentile</i>',
-    ),
-    yaxis=dict(
-        anchor='x',
-        gridcolor='rgba(102, 102, 102, 0.4)', gridwidth=1,
-        linecolor='#000', linewidth=1,
-        mirror=True, showgrid=False,
-        showline=True, zeroline=False,
-        showticklabels=True, tick0=0,
-        type='category',
-    )
+    )],
 )
-fig = go.Figure(data=data, layout=layout)
-py.iplot(fig,filename='EXAMPLES/logo')
+
+# update layout properties
+fig.update_layout(
+    autosize=False,
+    height=800,
+    width=700,
+    bargap=0.15,
+    bargroupgap=0.1,
+    barmode="stack",
+    hovermode="x",
+    margin=dict(r=20, l=300, b=75, t=125),
+    title=("Moving Up, Moving Down<br>" +
+           "<i>Percentile change in income between childhood and adulthood</i>"),
+)
+
+fig.show()
 ```
 
 #### Label Spectroscopy Data by Adding Multiple Images
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
 import numpy as np
 from scipy.signal import savgol_filter
 
-#simulate spectroscopy data
-def simulated_absorption(mu,sigma,intensity):
-    data = [np.random.normal(mu[i],sigma[i],intensity[i]) for i in range(len(mu))]
-    hists = [np.histogram(d,1000,range=(200,500),normed=True) for d in data]
-    ys = [y for y,x in hists]
-    s = savgol_filter(np.max(ys,axis = 0),41,3)
-    return hists[0][1],s
+# Simulate spectroscopy data
+def simulated_absorption(mu, sigma, intensity):
+    data = [np.random.normal(mu[i], sigma[i], intensity[i]) for i in range(len(mu))]
+    hists = [np.histogram(d, 1000, range=(200, 500), density=True) for d in data]
+    ys = [y for y, x in hists]
+    s = savgol_filter(np.max(ys, axis=0), 41, 3)
+    return hists[0][1], s
 
-mus = [[290,240,260],[330,350]]
-sigmas = [[4,6,10],[5,4]]
-intensities = [[100000,300000,700000],[40000,20000]]
+mus = [[290, 240, 260], [330, 350]]
+sigmas = [[4, 6, 10], [5, 4]]
+intensities = [[100000, 300000, 700000], [40000, 20000]]
+simulated_absorptions = [simulated_absorption(m, s, i) for m, s, i in
+                         zip(mus, sigmas, intensities)]
 
-simulated_absorptions = [simulated_absorption(m,s,i) for m,s,i in zip(mus,sigmas,intensities)]
+# Create figure
+fig = go.Figure()
 
-#create traces from data
-names=['Benzene','Naphthalene']
-colors = ['red','maroon']
-traces = [go.Scatter(x=x,y=y,name=n,line = dict(color=c)) for (x,y),n,c in zip(simulated_absorptions,names,colors)]
+# Create traces from data
+names = ["Benzene", "Naphthalene"]
+for (x, y), n in zip(simulated_absorptions, names):
+    fig.add_trace(go.Scatter(x=x, y=y, name=n))
 
-#add pictures using layout-images and then connect the image to its trace using annotations
-layout= go.Layout(
-    images= [dict(
-        source= "https://raw.githubusercontent.com/michaelbabyn/plot_data/master/benzene.png",
-        xref= "paper",
-        yref= "paper",
-        x= 0.75,
-        y= 0.65,
-        sizex= 0.3,
-        sizey= 0.3,
-        xanchor= "right",
-        yanchor= "bottom"
-      ),dict(
-        source= "https://raw.githubusercontent.com/michaelbabyn/plot_data/master/naphthalene.png",
+# Add images
+fig.update_layout(
+    images=[go.layout.Image(
+        source="https://raw.githubusercontent.com/michaelbabyn/plot_data/master/benzene.png",
         xref="paper",
-        yref= "paper",
-        x= 0.9,
-        y= 0.3,
-        sizex= 0.3,
-        sizey= 0.3,
+        yref="paper",
+        x=0.75,
+        y=0.65,
+        sizex=0.3,
+        sizey=0.3,
+        xanchor="right",
+        yanchor="bottom"
+    ), go.layout.Image(
+        source="https://raw.githubusercontent.com/michaelbabyn/plot_data/master/naphthalene.png",
+        xref="paper",
+        yref="paper",
+        x=0.9,
+        y=0.3,
+        sizex=0.3,
+        sizey=0.3,
+        xanchor="right",
+        yanchor="bottom"
+        )
+    ]
+)
 
-        xanchor= "right",
-        yanchor= "bottom"
-      )
-    ],
+# Add annotations
+fig.update_layout(
     annotations=[
-        dict(
-            x=93.0/300,
-            y=0.07/0.1,
-            xref='paper',
-            yref='paper',
+        go.layout.Annotation(
+            x=93.0 / 300,
+            y=0.07 / 0.1,
+            xref="paper",
+            yref="paper",
             showarrow=True,
             arrowhead=0,
             opacity=0.5,
             ax=250,
             ay=-40,
         ),
-        dict(
-            x=156/300,
-            y=0.04/0.1,
-            xref='paper',
-            yref='paper',
+        go.layout.Annotation(
+            x=156.0 / 300,
+            y=0.04 / 0.1,
+            xref="paper",
+            yref="paper",
             showarrow=True,
             arrowhead=0,
             opacity=0.5,
             ax=140,
             ay=-10,
         )
-    ],
-    title = 'Absorption Frequencies of Benzene and Naphthalene',
-    yaxis = dict(hoverformat='.3f', title='Absorption'),
-    xaxis = dict(title='Wavelength'),
-    showlegend=False,
-    height = 500,
-    width = 900
-
+    ]
 )
 
-fig = go.Figure(data=traces,layout=layout)
-py.iplot(fig,filename='EXAMPLES/spectroscopy')
+# Configure axes
+fig.update_xaxes(title_text="Wavelength")
+fig.update_yaxes(title_text="Absorption", hoverformat=".3f")
+
+# Configure other layout properties
+fig.update_layout(
+    title_text="Absorption Frequencies of Benzene and Naphthalene",
+    height=500,
+    width=900,
+    template="plotly_white"
+)
+
+fig.show()
 ```
 
 #### Zoom on Static Images
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
+# Create figure
+fig = go.Figure()
+
+# Constants
 img_width = 1600
 img_height = 900
 scale_factor = 0.5
 
-layout = go.Layout(
-    xaxis = go.layout.XAxis(
-        visible = False,
-        range = [0, img_width*scale_factor]),
-    yaxis = go.layout.YAxis(
-        visible=False,
-        range = [0, img_height*scale_factor],
-        # the scaleanchor attribute ensures that the aspect ratio stays constant
-        scaleanchor = 'x'),
-    width = img_width*scale_factor,
-    height = img_height*scale_factor,
-    margin = {'l': 0, 'r': 0, 't': 0, 'b': 0},
-    images = [go.layout.Image(
+# Add invisible scatter trace.
+# This trace is added to help the autoresize logic work.
+fig.add_trace(
+    go.Scatter(
+        x=[0, img_width * scale_factor],
+        y=[0, img_height * scale_factor],
+        mode="markers",
+        marker_opacity=0
+    )
+)
+
+# Configure axes
+fig.update_xaxes(
+    visible=False,
+    range=[0, img_width * scale_factor]
+)
+
+fig.update_yaxes(
+    visible=False,
+    range=[0, img_height * scale_factor],
+    # the scaleanchor attribute ensures that the aspect ratio stays constant
+    scaleanchor="x"
+)
+
+# Add image
+fig.update_layout(
+    images=[go.layout.Image(
         x=0,
-        sizex=img_width*scale_factor,
-        y=img_height*scale_factor,
-        sizey=img_height*scale_factor,
+        sizex=img_width * scale_factor,
+        y=img_height * scale_factor,
+        sizey=img_height * scale_factor,
         xref="x",
         yref="y",
         opacity=1.0,
         layer="below",
         sizing="stretch",
-        source='https://raw.githubusercontent.com/michaelbabyn/plot_data/master/bridge.jpg')]
-)
-# we add a scatter trace with data points in opposite corners to give the Autoscale feature a reference point
-fig = go.Figure(data=[{
-    'x': [0, img_width*scale_factor],
-    'y': [0, img_height*scale_factor],
-    'mode': 'markers',
-    'marker': {'opacity': 0}}],layout = layout)
-py.iplot(fig, filename='EXAMPLES/zoom_bridge')
-```
-
-#### Interactive Facial Recognition Overlays
-
-
-This example requires the python library `dlib`, which can be install with pip.
-
-`pip install dlib`
-
-Note: building this library requires `cmake` to be installed and may take some time.
-
-Also needed are the two `.dat` files (mmod_human_face_detector.dat and mmod_dog_hipsterizer.dat) which can be downloaded [here](https://github.com/davisking/dlib-models) compressed as .gz files. Download and uncompress them in the same root directory as this example.
-
-```python
-import plotly.plotly as py
-import plotly.graph_objs as go
-
-import numpy as np
-import dlib
-
-
-#load dlib's pretrained face detector
-cnn_human_detector = dlib.cnn_face_detection_model_v1('mmod_human_face_detector.dat')
-
-#choose a file in your current directory or download https://raw.githubusercontent.com/michaelbabyn/plot_data/master/beethoven.jpg
-f = 'beethoven.jpg'
-img = dlib.load_rgb_image(f)
-
-human_dets = cnn_human_detector(img,1)
-
-#load dlib's pretrained dog-face detector
-cnn_dog_detector = dlib.cnn_face_detection_model_v1('mmod_dog_hipsterizer.dat')
-
-dog_dets = cnn_dog_detector(img, 1)
-
-layout= go.Layout(
-    xaxis = go.layout.XAxis(
-        showticklabels = False,
-        showgrid=False,
-        zeroline=False,
-        range = [0, img.shape[1]]
-    ),
-    yaxis = go.layout.YAxis(
-        showticklabels = False,
-        showgrid=False,
-        zeroline=False,
-        range = [0, img.shape[0]],
-        scaleanchor = 'x'
-        ),
-    autosize=False,
-    height=img.shape[0],
-    width=img.shape[1],
-    margin = {'l': 0, 'r': 0, 't': 0, 'b': 0},
-    images= [dict(
-        source= "https://raw.githubusercontent.com/michaelbabyn/plot_data/master/beethoven.jpg",
-        x=0,
-        sizex=img.shape[1],
-        y=img.shape[0],
-        sizey=img.shape[0],
-        xref="x",
-        yref="y",
-        opacity=1.0,
-        layer="below",
-        sizing="stretch"
-     )]
+        source="https://raw.githubusercontent.com/michaelbabyn/plot_data/master/bridge.jpg")]
 )
 
-humans=[
-    go.Scatter(
-        x=[d.rect.left(), d.rect.right(), d.rect.right(), d.rect.left(), d.rect.left()],
-        y=[img.shape[0] - d.rect.top(),img.shape[0] - d.rect.top(),img.shape[0] - d.rect.bottom(),img.shape[0] - d.rect.bottom(),img.shape[0] - d.rect.top()],
-        hoveron = 'fills',
-        name = 'Human #{0}'.format(i+1),
-        text = 'confidence: {:.2f}'.format(d.confidence),
-        mode='lines',
-        line = dict(width=4,color='red'),
-        showlegend = False
-        )
-    for i,d in enumerate(human_dets)]
+# Configure other layout
+fig.update_layout(
+    width=img_width * scale_factor,
+    height=img_height * scale_factor,
+    margin={"l": 0, "r": 0, "t": 0, "b": 0},
+)
 
-dogs = [
-    go.Scatter(
-        x=[d.rect.left(),d.rect.right(),d.rect.right(),d.rect.left(),d.rect.left()],
-        y=[img.shape[0] - d.rect.top(),img.shape[0] - d.rect.top(),img.shape[0] - d.rect.bottom(),img.shape[0] - d.rect.bottom(),img.shape[0] - d.rect.top()],
-        hoveron = 'fills',
-        name = 'Dog #{0}'.format(i+1),
-        text = 'confidence: {:.2f}'.format(d.confidence),
-        mode='lines',
-        line = dict(width=4,color='blue'),
-        showlegend = False
-        )
-    for i,d in enumerate(dog_dets)]
-
-py.iplot(dict(data=humans+dogs,layout=layout),filename='EXAMPLES/facial_rec')
+fig.show()
 ```
 
 #### Reference
 See https://plot.ly/python/reference/#layout-images for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'images.ipynb', 'python/images/', 'Layout with images',
-    'How to add images to charts as background images or logos.',
-    title = 'Layout with images | plotly',
-    name = 'Images',
-    has_thumbnail='true', thumbnail='thumbnail/your-tutorial-chart.jpg',
-    language='python', page_type='example_index',
-    display_as='style_opt', order=4,
-    ipynb= '~notebook_demo/216')
-```
-
-```python
-
-```


### PR DESCRIPTION
This PR updates the images notebook.

I ended up removing the last, face recognition example because I couldn't get it to work.  It depends on a library that's hard to install using pip, and conda-forge seems to have an old version. It also depends on data files that are not in the repo.  We can revisit it later if we want to, but I cut it for now.

Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
