### PR TITLE
Update configuration-options notebook

### DIFF
--- a/notebooks/configuration-options.md
+++ b/notebooks/configuration-options.md
@@ -41,7 +41,7 @@ jupyter:
 #### Offline Configuration Options
 Now you can pass a `config` dictionary with all configurations options such as `scrollZoom`, `editable`, and `displayModeBar`. For the complete list of config options check out: https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js
 
-Enable Scroll Zoom
+##### Enable Scroll Zoom
 
 ```python
 import plotly.graph_objects as go
@@ -56,7 +56,7 @@ fig.add_trace(
 fig.show(config={'scrollZoom': True})
 ```
 
-Display ModeBar
+##### Display ModeBar
 
 ```python
 import plotly.graph_objects as go
@@ -71,7 +71,7 @@ fig.add_trace(
 fig.show(config={'displayModeBar': True})
 ```
 
-Edit Mode - change the title and axis titles
+##### Edit Mode - change the title and axis titles
 
 ```python
 import plotly.graph_objects as go
@@ -86,7 +86,7 @@ fig.add_trace(
 fig.show(config={'editable': True})
 ```
 
-Multiple Config Options at Once!
+##### Multiple Config Options at Once!
 
 ```python
 import plotly.graph_objects as go
@@ -105,7 +105,7 @@ fig.show(config={
 })
 ```
 
-Remove Modebar Buttons
+##### Remove Modebar Buttons
 
 ```python
 import plotly.graph_objects as go


### PR DESCRIPTION
Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [x] `v4upgrade: true` metadata added
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
