### PR TITLE
transform notebooks

### DIFF
--- a/notebooks/aggregations.md
+++ b/notebooks/aggregations.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.7
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.5
   plotly:
     description: How to use aggregates in Python with Plotly.
     display_as: transforms
@@ -24,24 +34,10 @@ jupyter:
     permalink: python/aggregations/
     thumbnail: thumbnail/aggregations.jpg
     title: Aggregations | Plotly
+    v4upgrade: true
 ---
 
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-#### Version Check
-Plotly's python package is updated frequently. Run `pip install plotly --upgrade` to use the latest version.
-
-```python
-import plotly
-plotly.__version__
-```
-
 #### Introduction
-
 
 Aggregates are a type of transform that can be applied to values in a given expression. Available aggregations are:
 
@@ -63,9 +59,7 @@ Function | Description
 #### Basic Example
 
 ```python
-import plotly.offline as off
-
-off.init_notebook_mode(connected=False)
+import plotly.io as pio
 
 subject = ['Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly']
 score = [1,6,2,8,2,9,4,5,1,5,2,8]
@@ -84,16 +78,15 @@ data = [dict(
   )]
 )]
 
+fig_dict = dict(data=data)
 
-off.iplot({'data': data}, validate=False)
+pio.show(fig_dict, validate=False)
 ```
 
 #### Aggregate Functions
 
 ```python
-import plotly.offline as off
-
-off.init_notebook_mode(connected=False)
+import plotly.io as pio
 
 subject = ['Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly']
 score = [1,6,2,8,2,9,4,5,1,5,2,8]
@@ -141,17 +134,17 @@ layout = dict(
   )]
 )
 
-off.iplot({'data': data,'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+
+pio.show(fig_dict, validate=False)
 ```
 
 #### Histogram Binning
 
 ```python
-import plotly.offline as off
+import plotly.io as pio
 
 import pandas as pd
-
-off.init_notebook_mode(connected=False)
 
 df = pd.read_csv("https://plot.ly/~public.health/17.csv")
 
@@ -214,17 +207,17 @@ layout = dict(
   )]
 )
 
-off.iplot({'data': data,'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+
+pio.show(fig_dict, validate=False)
 ```
 
 #### Mapping with Aggregates
 
 ```python
-import plotly.offline as off
+import plotly.io as pio
 
 import pandas as pd
-
-off.init_notebook_mode(connected=False)
 
 df = pd.read_csv("https://raw.githubusercontent.com/bcdunbar/datasets/master/worldhappiness.csv")
 
@@ -275,31 +268,10 @@ layout = dict(
   )]
 )
 
-off.iplot({'data': data,'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+
+pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
 See https://plot.ly/python/reference/ for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'aggregations.ipynb', 'python/aggregations/', 'Aggregations',
-    'How to use aggregates in Python with Plotly.',
-    title = 'Aggregations | Plotly',
-    has_thumbnail='true', thumbnail='thumbnail/aggregations.jpg',
-    language='python', uses_plotly_offline=True,
-    page_type='example_index',
-    display_as='transforms', order=3,
-    ipynb= '~notebook_demo/192')
-```
-
-```python
-
-```

--- a/notebooks/filter.md
+++ b/notebooks/filter.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.7
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.5
   plotly:
     description: How to use filters in Python with Plotly.
     display_as: transforms
@@ -24,28 +34,13 @@ jupyter:
     permalink: python/filter/
     thumbnail: thumbnail/filter.jpg
     title: Filter | Plotly
+    v4upgrade: true
 ---
-
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-#### Version Check
-Plotly's python package is updated frequently. Run `pip install plotly --upgrade` to use the latest version.
-
-```python
-import plotly
-plotly.__version__
-```
 
 #### Basic Example
 
 ```python
-import plotly.offline as off
-
-off.init_notebook_mode(connected=True)
+import plotly.io as pio
 
 subject = ['Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly']
 score = [1,6,2,8,2,9,4,5,1,5,2,8]
@@ -67,31 +62,10 @@ layout = dict(
     title = 'Scores > 4'
 )
 
-off.iplot({'data': data, 'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+
+pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
 See https://plot.ly/python/reference/ for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'filter.ipynb', 'python/filter/', 'Filter',
-    'How to use filters in Python with Plotly.',
-    title = 'Filter | Plotly',
-    has_thumbnail='true', thumbnail='thumbnail/filter.jpg',
-    language='python', uses_plotly_offline=True,
-    page_type='example_index',
-    display_as='transforms', order=1,
-    ipynb= '~notebook_demo/195')
-```
-
-```python
-
-```

--- a/notebooks/group-by.md
+++ b/notebooks/group-by.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.7
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.5
   plotly:
     description: How to use group by in Python with Plotly.
     display_as: transforms
@@ -24,28 +34,13 @@ jupyter:
     permalink: python/group-by/
     thumbnail: thumbnail/groupby.jpg
     title: Group By | Plotly
+    v4upgrade: true
 ---
-
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-#### Version Check
-Plotly's python package is updated frequently. Run `pip install plotly --upgrade` to use the latest version.
-
-```python
-import plotly
-plotly.__version__
-```
 
 #### Basic Example
 
 ```python
-import plotly.offline as off
-
-off.init_notebook_mode(connected=True)
+import plotly.io as pio
 
 subject = ['Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly','Moe','Larry','Curly']
 score = [1,6,2,8,2,9,4,5,1,5,2,8]
@@ -66,31 +61,9 @@ data = [dict(
   )]
 )]
 
-off.iplot({'data': data}, validate=False)
+fig_dict = dict(data=data)
+pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
 See https://plot.ly/python/reference/ for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git
-import publisher
-publisher.publish(
-    'groupby.ipynb', 'python/group-by/', 'Group By',
-    'How to use group by in Python with Plotly.',
-    title = 'Group By | Plotly',
-    has_thumbnail='true', thumbnail='thumbnail/groupby.jpg',
-    language='python', uses_plotly_offline=True,
-    page_type='example_index',
-    display_as='transforms', order=2,
-    ipynb= '~notebook_demo/194')
-```
-
-```python
-
-```

--- a/notebooks/multiple-transforms.md
+++ b/notebooks/multiple-transforms.md
@@ -6,11 +6,21 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.1
+      jupytext_version: 1.1.7
   kernelspec:
-    display_name: Python 2
+    display_name: Python 3
     language: python
-    name: python2
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.5
   plotly:
     description: How to use multiple transforms (filter, group by, and aggregates)
       in Python with Plotly.
@@ -25,30 +35,15 @@ jupyter:
     permalink: python/multiple-transforms/
     thumbnail: thumbnail/multiple-transforms.jpg
     title: Multiple Transforms | Plotly
+    v4upgrade: true
 ---
-
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-#### Version Check
-Plotly's python package is updated frequently. Run `pip install plotly --upgrade` to use the latest version.
-
-```python
-import plotly
-plotly.__version__
-```
 
 #### Filter and Group By
 
 ```python
-import plotly.offline as off
+import plotly.io as pio
 
 import pandas as pd
-
-off.init_notebook_mode(connected=False)
 
 df = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv")
 
@@ -95,15 +90,14 @@ layout = dict(
     )
 )
 
-
-off.iplot({'data': data, 'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+pio.show(fig_dict, validate=False)
 ```
 
 #### Filter and Aggregate
 
 ```python
-import plotly.offline as off
-
+import plotly.io as pio
 import pandas as pd
 
 df = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/gapminderDataFiveYear.csv")
@@ -146,13 +140,15 @@ layout = dict(
 )
 
 
-off.iplot({'data': data, 'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+
+pio.show(fig_dict, validate=False)
 ```
 
 #### All Transforms
 
 ```python
-import plotly.offline as off
+import plotly.io as pio
 
 import pandas as pd
 
@@ -211,32 +207,9 @@ layout = dict(
     )
 )
 
-
-off.iplot({'data': data, 'layout': layout}, validate=False)
+fig_dict = dict(data=data, layout=layout)
+pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
 See https://plot.ly/python/reference/ for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'multiple-transforms.ipynb', 'python/multiple-transforms/', 'Multiple Transforms',
-    'How to use multiple transforms (filter, group by, and aggregates) in Python with Plotly.',
-    title = 'Multiple Transforms | Plotly',
-    has_thumbnail='true', thumbnail='thumbnail/multiple-transforms.jpg',
-    language='python', uses_plotly_offline=True,
-    page_type='example_index',
-    display_as='transforms', order=4,
-    ipynb= '~notebook_demo/193')
-```
-
-```python
-
-```


### PR DESCRIPTION
This PR includes minimal v4 compatibility updates for the transform notebooks.

 - aggregations
 - filter
 - multiple-transforms
 - group-by

Doc upgrade checklist:

- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `fig.show()` at the end of each example
- [x] `v4upgrade: true` metadata added