### PR TITLE
Version 4 migration guide

### DIFF
--- a/notebooks/v4-migration.md
+++ b/notebooks/v4-migration.md
@@ -32,7 +32,7 @@ jupyter:
     layout: user-guide
     permalink: python/v4-migration/
     thumbnail: thumbnail/static-image-export.png
-    title: Displaying Figures | plotly
+    title: Version 4 migration guide | plotly
     order: 1
 ---
 


### PR DESCRIPTION
The version 4 migration guide

Closes https://github.com/plotly/plotly.py-docs/issues/9

cc @nicolaskruchten

 - [ ] `plotly_express` -> `plotly.express`
