### PR TITLE
Update heading levels so that H3 is the largest

### DIFF
--- a/notebooks/creating-and-updating-figures.md
+++ b/notebooks/creating-and-updating-figures.md
@@ -35,9 +35,9 @@ jupyter:
     v4upgrade: true
 ---
 
-# Representing Figures
+### Representing Figures
 
-## Figures as dictionaries
+#### Figures as dictionaries
 The goal of plotly.py is to provide a pleasant Python interface for creating figure specifications for display in the Plotly.js JavaScript library. In Plotly.js, a figure is specified by a declarative JSON data structure, and so the ultimate responsibility of plotly.py is to produce Python dictionaries that can be serialized into a JSON data structure that represents a valid figure.
 
 As a concrete example, here is a Python dictionary that represents a figure containing a single bar trace and a title.
@@ -64,7 +64,7 @@ The [*Full Reference*](https://plot.ly/python/reference/) page contains descript
 If working from the *Full Reference* to build figures as Python dictionaries and lists suites your needs, go for it! This is a perfectly valid way to use plotly.py to build figures.  On the other hand, if you would like an API that offers a bit more assistance, read on to learn about graph objects.
 
 
-## Figures as graph objects
+#### Figures as graph objects
 As an alternative to working with Python dictionaries, plotly.py provides a hierarchy of classes called "graph objects" that may be used to construct figures. Graph objects have several benefits compared to plain dictionaries.
 
  1. Graph objects provide precise data validation. So if you provide an invalid property name or an invalid property value, an exception will be raised with a helpful error message describing the problem.
@@ -101,10 +101,10 @@ fig.show()
 Once you have a figure as a graph object, you can retrieve the dictionary representation using the `fig.to_dict()` method.  You can also retrieve the JSON string representation using the `fig.to_json()` method.
 
 
-# Creating figures
+### Creating figures
 This section summarizes several ways to create new graph object figures with plotly.py
 
-### Constructor
+#### Constructor
 As demonstrated above, you can build a complete figure by passing trace and layout specifications to the `plotly.graph_objects.Figure` constructor.  These trace and layout specifications can be either dictionaries or graph objects. Here, for example, the traces are specified using graph objects and the layout is specified as a dictionary.
 
 ```python
@@ -116,7 +116,7 @@ fig = go.Figure(
 fig.show()
 ```
 
-### Plotly express
+#### Plotly express
 Plotly express (included as the `plotly.express` module) is a high-level data exploration API that produces graph object figures.
 
 ```python
@@ -130,7 +130,7 @@ fig = px.scatter(iris, x="sepal_width", y="sepal_length", color="species")
 fig.show()
 ```
 
-### Figure factories
+#### Figure factories
 Figure factories (included in plotly.py in the `plotly.figure_factory` module) are functions that produce graph object figures, often to satisfy the needs of specialized domains.  Here's an example of using the `create_quiver` figure factory to construct a graph object figure that displays a 2D quiver plot.
 
 ```python
@@ -144,7 +144,7 @@ fig = ff.create_quiver(x1, y1, u1, v1)
 fig.show()
 ```
 
-### Make subplots
+#### Make subplots
 The `plotly.subplots.make_subplots` function produces a graph object figure that is preconfigured with a grid of subplots that traces can be added to.  The `add_trace` function will be discussed more below.
 
 ```python
@@ -155,10 +155,10 @@ fig.add_trace(go.Bar(y=[2, 1, 3]), row=1, col=2)
 fig.show()
 ```
 
-# Updating figures
+### Updating figures
 Regardless of how a graph object figure was constructed, it can be updated by adding additional traces and modifying its properties.
 
-### Adding traces
+#### Adding traces
 New traces can be added to a graph object figure using the `add_trace` method.  This method accepts a graph object trace (an instance of `go.Scatter`, `go.Bar`, etc.) and adds it to the figure.  This allows you to start with an empty figure, and add traces to it sequentially.
 
 ```python
@@ -185,7 +185,7 @@ fig.add_trace(
 fig.show()
 ```
 
-### Adding traces to subplots
+#### Adding traces to subplots
 If a figure was created using `plotly.subplots.make_subplots`, then the `row` and `col` argument to `add_trace` can be used to add a trace to a particular subplot.
 
 ```python
@@ -213,7 +213,7 @@ fig.add_trace(reference_line, row=1, col=3)
 fig.show()
 ```
 
-### Add trace convenience methods
+#### Add trace convenience methods
 As an alternative to the `add_trace` method, graph object figures have a family of methods of the form `add_{trace}`, where `{trace}` is the name of a trace type, for constructing and adding traces of each trace type. Here is the previous subplot example, adapted to add the scatter trace using `fig.add_scatter` and to add the bar trace using `fig.add_bar`.
 
 ```python
@@ -224,7 +224,7 @@ fig.add_bar(y=[2, 1, 3], row=1, col=2)
 fig.show()
 ```
 
-### Magic underscore notation
+#### Magic underscore notation
 To make it easier to work with nested properties graph object constructors, and many graph object methods, support magic underscore notation. This allows you to reference nested properties by joining together multiple nested property names with underscores.
 
 For example, specifying the figure title in the figure constructor *without* magic underscore notation requires setting the `layout` argument to `dict(title=dict(text="A Chart"))`. Similarly, setting the line color of a scatter trace requires setting the `marker` property to `dict(color="crimson")`.
@@ -253,7 +253,7 @@ Magic underscore notation is supported throughout the graph objects API, and it 
 
 > Note: When you see keyword arguments with underscores passed to a graph object constructor or method, it is almost always safe to assume that it is an application of magic underscore notation. We have to say "almost always" rather than "always" because there are a few property names in the plotly schema that contain underscores: error_x, error_y, error_z, copy_xstyle, copy_ystyle, copy_zstyle, paper_bgcolor, and plot_bgcolor.  These were added back in the early days of the library (2012-2013) before we standardized on banning underscores from property names.
 
-### The update layout method
+#### The update layout method
 Graph object figures support an `update_layout` method that may be used to update multiple nested properties of a figure's layout.  Here is an example of updating the text and font size of a figure's title using `update_layout`.
 
 ```python
@@ -286,7 +286,7 @@ fig.update_layout(
 ```
 
 
-### The update traces method
+#### The update traces method
 Graph object figures support an `update_traces` method that may be used to update multiple nested properties of one or more of a figure's traces.  To show some examples, we will start with a figure that contains bar and scatter traces across two subplots.
 
 ```python
@@ -436,7 +436,7 @@ fig.update_traces(
 fig.show()
 ```
 
-### The for each trace method
+#### The for each trace method
 Suppose the updates that you want to make to a collection of traces depend on the current values of certain trace properties.  The `update_traces` method cannot handle this situation, but the `for_each_trace` method can.
 
 As its first argument, the `for_each_trace` method accepts a function that accepts and updates one trace at a time.  Like `update_traces`, `for_each_trace` also accepts `selector`, `row`, and `col` arguments to control which traces should be considered.
@@ -456,7 +456,7 @@ fig.for_each_trace(
 fig.show()
 ```
 
-### The update axis methods
+#### The update axis methods
 Graph object figures support `update_xaxes` and `update_yaxes` methods that may be used to update multiple nested properties of one or more of a figure's axes.  Here is an example of using `update_xaxes` to disable the vertical grid lines across all subplots in a figure produced by plotly express.
 
 ```python
@@ -471,7 +471,7 @@ fig.show()
 There are also `for_each_xaxis` and `for_each_yaxis` methods that are analogous to the `for_each_trace` method described above. For non-cartesian subplot types (e.g. polar), there are additional `update_{type}` and `for_each_{type}` methods (e.g. `update_polar`, `for_each_polar`).
 
 
-### Chaining figure operations
+#### Chaining figure operations
 All of the figure update operations described above are methods that return a reference to the figure being modified.  This makes it possible the chain multiple figure modification operations together into a single expression.
 
 Here is an example of a chained expression that creates a faceted scatter plot with OLS trend lines using plotly express, sets the title font size using `update_layout`, disables vertical grid lines using `update_xaxes`, updates the width and dash pattern of the trend lines using `update_traces`, and then displays the figure using `show`.
@@ -489,7 +489,7 @@ iris = px.data.iris()
 ).show()
 ```
 
-### Property assignment
+#### Property assignment
 Trace and layout properties can be updated using property assignment syntax.  Here is an example of setting the figure title using property assignment.
 
 ```python

--- a/notebooks/getting-started.md
+++ b/notebooks/getting-started.md
@@ -35,14 +35,14 @@ jupyter:
 ---
 
 <!-- #region -->
-## Overview
+### Overview
 The plotly Python library ([plotly.py](https://plot.ly/python/)) is an interactive, [open-source](https://github.com/plotly/plotly.py) plotting library that supports over 40 unique chart types covering a wide range of statistical, financial, geographic, scientific, and 3-dimensional use-cases.
 
 Built on top of the Plotly JavaScript library ([plotly.js](https://plot.ly/javascript/)), plotly.py enables Python users to create beautiful interactive web-based visualizations that can be displayed in Jupyter notebooks, saved to standalone HTML files, or served as part of pure Python-built web applications using Dash.
 
 Thanks to deep integration with the [orca](https://github.com/plotly/orca) image export utility, plotly.py also provides great support for non-web contexts including desktop editors (e.g. QtConsole, Spyder, PyCharm) and static document publishing (e.g. exporting notebooks to PDF with high-quality vector images).
 
-## Installation
+### Installation
 plotly.py may be installed using pip...
 
 ```
@@ -65,7 +65,7 @@ fig.write_html('first_figure.html', auto_open=True)
 ```
 
 <!-- #region -->
-### Jupyter Notebook Support
+#### Jupyter Notebook Support
 For use in the classic [Jupyter Notebook](https://jupyter.org/), install the `notebook` and `ipywidgets`
 packages using pip...
 
@@ -104,7 +104,7 @@ fig
 <!-- #region -->
 See [*Displaying Figures in Python*](https://plot.ly/python/renderers/) for more information on the renderers framework, and see [*Plotly FigureWidget Overview*](https://plot.ly/python/figurewidget/) for more information on using `FigureWidget`.
 
-### JupyterLab Support (Python 3.5+)
+#### JupyterLab Support (Python 3.5+)
 For use in [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), install the `jupyterlab` and `ipywidgets`
 packages using pip...
 
@@ -173,7 +173,7 @@ fig
 <!-- #region -->
 See [*Displaying Figures in Python*](https://plot.ly/python/renderers/) for more information on the renderers framework, and see [*Plotly FigureWidget Overview*](https://plot.ly/python/figurewidget/) for more information on using `FigureWidget`.
 
-### Static Image Export Support
+#### Static Image Export Support
 plotly.py supports static image export using the `to_image` and `write_image`
 functions in the `plotly.io` package. This functionality requires the
 installation of the plotly [orca](https://github.com/plotly/orca) command line utility and the
@@ -206,7 +206,7 @@ fig.write_image('figure.png')
 <!-- #region -->
 See [*Static Image Export in Python*](https://plot.ly/python/static-image-export/) for more information on static image export.
 
-### Extended Geo Support
+#### Extended Geo Support
 Some plotly.py features rely on fairly large geographic shape files. The county
 choropleth figure factory is one such example. These shape files are distributed as a
 separate `plotly-geo` package.  This package can be installed using pip...
@@ -223,7 +223,7 @@ $ conda install -c plotly plotly-geo=1.0.0
 
 See [*USA County Choropleth Maps in Python*](https://plot.ly/python/county-choropleth/) for more information on the county choropleth figure factory.
 
-### Chart Studio Support
+#### Chart Studio Support
 The `chart-studio` package can be used to upload plotly figures to Plotly's Chart
 Studio Cloud or On-Prem services.  This package can be installed using pip...
 
@@ -239,7 +239,7 @@ $ conda install -c plotly chart-studio=1.0.0
 
 > **Note:** This package is optional, and if it is not installed it is not possible for figures to be uploaded to the Chart Studio cloud service.
 
-## Where to next?
+### Where to next?
 Now that you have everything installed, you are ready to start reading and running examples of [basic charts](https://plot.ly/python/basic-charts/), [statistical charts](https://plot.ly/python/statistical-charts/), [scientific charts](https://plot.ly/python/scientific-charts/), [financial charts](https://plot.ly/python/#financial-charts), [geographic charts](https://plot.ly/python/maps/), and [3-dimensional charts](https://plot.ly/python/3d-charts/).
 
 For a complete overview of all of the ways that figures can be created and updated, see the [*Plotly User Guide for Python*](https://plot.ly/python/user-guide/).

--- a/notebooks/renderers.md
+++ b/notebooks/renderers.md
@@ -35,7 +35,7 @@ jupyter:
     title: Displaying Figures | plotly
 ---
 
-# Displaying plotly figures
+### Displaying plotly figures
 This section covers the many ways to display plotly figures from Python.  At the highest level, there are three general approaches:
 
  1. Using the renderers framework in the context of a script or notebook
@@ -44,7 +44,7 @@ This section covers the many ways to display plotly figures from Python.  At the
 
 Each of these approaches is discussed below.
 
-# Displaying figures using the renderers framework
+### Displaying figures using the renderers framework
 
 The renderers framework is a flexible approach for displaying plotly figures in a variety of contexts.  To display a figure using the renderers framework, you call the `.show` method on a graph object figure, or pass the figure to the `plotly.io.show` function. With either approach, plotly.py will display the figure using the current default renderer(s).
 
@@ -76,7 +76,7 @@ Next, we will show how to configure the default renderer.  After that, we will d
 
 > Note: The renderers framework is a generalization of the `plotly.offline.iplot` and `plotly.offline.plot` functions that were the recommended way to display figures prior to plotly.py version 4.  These functions have been reimplemented using the renderers framework and are still supported for backward compatibility, but they will not be discussed here.
 
-## Setting the default renderer
+#### Setting the default renderer
 The current and available renderers are configured using the `plotly.io.renderers` configuration object.  Display this object to see the current default renderer and the list of all available renderers.
 
 ```python
@@ -95,7 +95,7 @@ pio.renderers.default = "browser"
 
 It is also possible to set the default renderer using a system environment variable.  At startup, plotly.py checks for the existence of an environment variable named `PLOTLY_RENDERER`.  If this environment variable is set to the name of an available renderer, this renderer is set as the default.
 
-## Overriding the default renderer
+#### Overriding the default renderer
 It is also possible to override the default renderer temporarily by passing the name of an available renderer as the `renderer` keyword argument to the `.show` method.  Here is an example of displaying a figure using the `svg` renderer (described below) without changing the default renderer.
 
 ```python
@@ -107,41 +107,41 @@ fig = go.Figure(
 fig.show(renderer="svg")
 ```
 
-## The built-in renderers
+#### The built-in renderers
 In this section, we will describe the built-in renderers so that you can choose the one(s) that best suit your needs.
 
-### Interactive renderers
+##### Interactive renderers
 Interactive renderers display figures using the Plotly.js JavaScript library and are fully interactive, supporting pan, zoom, hover tooltips, etc.
 
-#### `notebook`
+###### `notebook`
 This renderer is intended for use in the classic [Jupyter Notebook](https://jupyter.org/install.html) (not JupyterLab).  The full Plotly.js JavaScript library bundle is added to the notebook the first time a figure is rendered, so this renderer will work without an internet connection.
 
 This renderer is a good choice for notebooks that will be exported to HTML files (Either using [nbconvert](https://nbconvert.readthedocs.io/en/latest/) or the "Download as HTML" menu action) because the exported HTML files will work without an internet connection.
 
 > Note: Adding the Plotly.js bundle to the notebook does add a few megabytes to the notebook size, so if you can count on having an internet connection you may want to consider the `notebook_connected` renderer.
 
-#### `notebook_connected`
+###### `notebook_connected`
 This renderer is the same as `notebook`, except the Plotly.js JavaScript library bundle is loaded from an online CDN location.  This saves a few megabytes in notebook size, but an internet connection is required in order to display figures that are rendered this way.
 
 This renderer is a good choice for notebooks that will be shared with [nbviewer](https://nbviewer.jupyter.org/) since users must have an active internet connection to access nbviewer in the first place.
 
-#### `kaggle` and `azure`
+###### `kaggle` and `azure`
 These are aliases for `notebook_connected` because this renderer is a good choice for use with [Kaggle kernels](https://www.kaggle.com/docs/kernels) and [Azure Notebooks](https://notebooks.azure.com/).
 
-#### `colab`
+###### `colab`
 This is a custom renderer for use with [Google Colab](https://colab.research.google.com).
 
-#### `browser`
+###### `browser`
 This renderer will open a figure in a browser tab using the default web browser.  This renderer can only be used when the Python kernel is running locally on the same machine as the web browser, so it is not compatible with Jupyter Hub or online notebook services.
 
 > Implementation Note 1: The "default browser" is the browser that is chosen by the Python [`webbrowser`](https://docs.python.org/3.7/library/webbrowser.html) module.
 
 > Implementation Note 2: The `browser` renderer works by setting up a single use local webserver on a local port. Since the webserver is shut down as soon as the figure is served to the browser, the figure will not be restored if the browser is refreshed.
 
-#### `firefox`, `chrome`, and `chromium`
+###### `firefox`, `chrome`, and `chromium`
 These renderers are the same as the `browser` renderer, but they force the use of a particular browser.
 
-#### `iframe` and `iframe_connected`
+###### `iframe` and `iframe_connected`
 These renderers write figures out as standalone HTML files and then display [`iframe`](https://www.w3schools.com/html/html_iframe.asp) elements that reference these HTML files. The `iframe` renderer will include the Plotly.js JavaScript bundle in each HTML file that is written, while the `iframe_connected` renderer includes only a reference to an online CDN location from which to load Plotly.js.  Consequently, the `iframe_connected` renderer outputs files that are smaller than the `iframe` renderer, but it requires an internet connection while the `iframe` renderer can operate offline.
 
 This renderer may be useful when working with notebooks than contain lots of large figures.  When using the `notebook` or `notebook_connected` renderer, all of the data for all of the figures in a notebook are stored inline in the notebook itself. If this would result in a prohibitively large notebook size, an `iframe` or `iframe_connected` renderer could be used instead. With the iframe renderers, the figure data are stored in the individual HTML files rather than in the notebook itself, resulting in a smaller notebook size.
@@ -149,17 +149,17 @@ This renderer may be useful when working with notebooks than contain lots of lar
 > Implementation Note: The HTML files written by the iframe renderers are stored in a subdirectory named `iframe_figures`.  The HTML files are given names based on the execution number of the notebook cell that produced the figure. This means that each time a notebook kernel is restarted, any prior HTML files will be overwritten.  This also means that you should not store multiple notebooks using an iframe renderer in the same directory, because this could result in figures from one notebook overwriting figures from another notebook.
 
 
-#### `plotly_mimetype`
+###### `plotly_mimetype`
 
 The `plotly_mimetype` renderer creates a specification of the plotly figure (called a MIME-type bundle), and requests that the current user interface displays it. User interfaces that support this renderer include [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) (requires the [`jupyterlab-plotly`](https://www.npmjs.com/package/jupyterlab-plotly) extension), [nteract](https://nteract.io/), and the Visual Studio Code [notebook interface](https://code.visualstudio.com/docs/python/jupyter-support).
 
-#### `jupyterlab`, `nteract`, and `vscode`
+###### `jupyterlab`, `nteract`, and `vscode`
 These are aliases for `plotly_mimetype` since this renderer is a good choice when working in JupyterLab, nteract, and the Visual Studio Code notebook interface.
 
-### Static image renderers
+##### Static image renderers
 A set of renderers is provided for displaying figures as static images.  These renderers all rely on the orca static image export utility. See the [Static Image Export](https://plot.ly/python/static-image-export/) page for more information on getting set up with orca.
 
-#### `png`, `jpeg`, and `svg`
+###### `png`, `jpeg`, and `svg`
 These renderers display figures as static PNG, JPEG, and SVG images respectively.  These renderers are useful for user interfaces that do not support inline HTML output, but do support inline static images.  Examples include the [QtConsole](https://qtconsole.readthedocs.io/en/stable/), [Spyder](https://www.spyder-ide.org/), and the PyCharm [notebook interface](https://www.jetbrains.com/help/pycharm/jupyter-notebook-support.html).
 
 ```python
@@ -171,19 +171,19 @@ fig = go.Figure(
 fig.show(renderer="png")
 ```
 
-#### `pdf`
+###### `pdf`
 This renderer displays figures as static PDF files. This is especially useful for notebooks that will be exported to PDF files using the LaTeX export capabilities of nbconvert.
 
-### Other renderers
+##### Other renderers
 Other miscellaneous renderers
 
-#### `json`
+###### `json`
 In editors that support it (JupyterLab, nteract, and the Visual Studio Code notebook interface), this renderer displays the JSON representation of a figure in a collapsible interactive tree structure.  This can be very useful for examining the structure of complex figures
 
-### Multiple renderers
+##### Multiple renderers
 You can specify that multiple renderers should be used by joining their names on `"+"` characters.  This is useful when writing code that needs to support multiple contexts.  For example, if a notebook specifies a default renderer string of  `"notebook+plotly_mimetype+pdf"`then this notebook would be able to run in the classic Jupyter Notebook, in JupyterLab, and it would support being exported to PDF using nbconvert.
 
-## Customizing built-in renderers
+#### Customizing built-in renderers
 Most built-in renderers have configuration options to customize their behavior.  To view a description of a renderer, including its configuration options, access the renderer object using dictionary-style key lookup on the `plotly.io.renderers` configuration object and then display it.  Here is an example of accessing and displaying the `png` renderer.
 
 ```python
@@ -224,12 +224,12 @@ fig = go.Figure(
 fig.show(renderer="png", width=800, height=300)
 ```
 
-# Displaying figures using Dash
+### Displaying figures using Dash
 Dash is a Python framework for building web applications, and it provides built-in support for displaying Plotly figures. See the [Dash User Guide](https://dash.plot.ly/) for more information.
 
 It is important to note that Dash does not use the renderers framework discussed above, so you should not use the `.show` figure method or the `plotly.io.show` function inside Dash applications.
 
-# Displaying figures using ipywidgets
+## Displaying figures using ipywidgets
 Plotly figures can be displayed in [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/) contexts using `plotly.graph_objects.FigureWidget` objects.  `FigureWidget` is a figure graph object (Just like `plotly.graph_objects.Figure`) so you can add traces to it and update it just like a regular `Figure`.  But `FigureWidget` is also an ipywidgets object, which means that you can display it alongside other ipywidgets to build user interfaces right in the notebook.  See the [Plotly FigureWidget Overview](https://plot.ly/python/figurewidget/) for more information on integrating plotly figures with ipywidgets.
 
 It is important to note that `FigureWidget` does not use the renderers framework discussed above, so you should not use the `.show` figure method or the `plotly.io.show` function on `FigureWidget` objects.

--- a/notebooks/templates.md
+++ b/notebooks/templates.md
@@ -35,13 +35,13 @@ jupyter:
     title: Theming and templates | plotly
 ---
 
-# Theming and templates
+### Theming and templates
 The Plotly Python library comes pre-loaded with several themes that you can get started using right away, and it also provides support for creating and registering your own themes.
 
 > Note on terminology: Theming generally refers to the process of defining default styles for visual elements.  Themes in plotly are implemented using objects called templates. Templates are slightly more general than traditional themes because in addition to defining default styles, templates can pre-populate a figure with visual elements like annotations, shapes, images, and more. In the documentation we will refer to the overall process of defining default styles as theming, and when in comes to the plotly API we will talk about how themes are implemented using templates.
 
-## Using built-in themes
-### View available themes
+### Using built-in themes
+#### View available themes
 To see information about the available themes and the current default theme, display the `plotly.io.templates` configuration object like this.
 
 ```python
@@ -52,7 +52,7 @@ pio.templates
 From this, we can see that the default theme is `"plotly"`, and we can see the names of several additional themes that we can choose from.
 
 
-### Specifying themes in plotly express
+#### Specifying themes in plotly express
 All plotly express functions accept a `template` argument that can be set to the name of a registered theme (or to a `Template` object as discussed later in this section). Here is an example of using plotly express to build and display the same scatter plot with five different themes.
 
 ```python
@@ -69,7 +69,7 @@ for template in ["plotly", "plotly_white", "plotly_dark", "ggplot2", "seaborn", 
     fig.show()
 ```
 
-### Specifying themes in graph object figures
+#### Specifying themes in graph object figures
 The theme for a particular graph object figure can be specified by setting the `template` property of the figure's `layout` to the name of a registered theme (or to a `Template` object as discussed later in this section).  Here is an example of constructing a surface plot and then displaying it with each of five themes.
 
 ```python
@@ -91,7 +91,7 @@ for template in ["plotly", "plotly_white", "plotly_dark", "ggplot2", "seaborn", 
     fig.show()
 ```
 
-### Specifying a default themes
+#### Specifying a default themes
 If a theme is not provided to a plotly express function or to a graph object figure, then the default theme is used.  The default theme starts out as `"plotly"`, but it can be changed by setting the `plotly.io.templates.default` property to the name of a registered theme.
 
 Here is an example of changing to default theme to `"plotly_white"` and then constructing a scatter plot with plotly express without providing a template.
@@ -114,7 +114,7 @@ fig = px.scatter(gapminder_2007,
 fig.show()
 ```
 
-### Disable default theming
+#### Disable default theming
 If you do not wish to use any of the new themes by default, or you want your figures to look exactly the way they did prior to plotly.py version 4, you can disable default theming by setting the default theme to `"none"`.
 
 ```python
@@ -122,12 +122,12 @@ import plotly.io as pio
 pio.templates.default = "none"
 ```
 
-## Creating themes
-### Representing themes with Template objects
+### Creating themes
+#### Representing themes with Template objects
 
 Themes in plotly.py are represented by instances of the `Template` class from the `plotly.graph_objects.layout` module. A `Template` is a graph object that contains two top-level properties: `layout` and `data`.  These template properties are described in their own sections below.
 
-### The template layout property
+#### The template layout property
 The `layout` property of a template is a graph object with the exact same structure as the `layout` property of a figure.  When you provide values for properties of the template's `layout`, these values will be used as the defaults in any figure that this template is applied to.
 
 Here is an example that creates a template that sets the default title font to size 24 Rockwell, and then constructs a graph object figure with this template.
@@ -147,7 +147,7 @@ fig.show()
 
 > Note: this example uses magic underscore notation to write `go.Layout(title=dict(font=dict(...)))` as `go.Layout(title_font=dict(...))`
 
-### The template data property
+#### The template data property
 The `data` property of a template is used to customize the default values of the properties of traces that are added to a figure that the template is applied to.  This `data` property holds a graph object, with type `go.layout.template.Data`, that has a property named after each supported trace type. These trace type properties are then assigned lists or tuples of graph object traces of the corresponding type.
 
 Here is an example that creates a template that sets the default scatter trace markers to be size 20 diamonds, and then constructs a graph object figure with this template.
@@ -188,7 +188,7 @@ fig.show()
 Note that because we built the template with a list of 3 scatter trace graph objects (one each for the diamond, square, and circle symbols), the forth scatter trace in the figure cycles around and takes on the defaults specified in the first template trace (The diamond symbol).
 
 
-### Theming object tuple properties
+#### Theming object tuple properties
 Some properties in the figure hierarchy are specified as tuples of objects.  For example, the text annotations for a graph object figure are stored as a tuple of `go.layout.Annotation` objects in the `annotations` property of the figure's layout.
 
 To use a template to configure the default properties of all of the elements in an object tuple property (e.g. `layout.annotations`), use the `*defaults`  property in the template that corresponds to the tuple property (e.g. `layout.template.layout.annotationdefaults`).  The `*defaults` template property should be set to a single graph object that matches the type of the elements of the corresponding tuple. The properties of this `*defaults` object in the template will be applied to all elements of the object tuple in the figure that the template is applied to.
@@ -212,7 +212,7 @@ fig.update_layout(
 fig.show()
 ```
 
-### Including tuple elements in a theme
+#### Including tuple elements in a theme
 
 The previous section described how to use a template to customize the default properties of tuple elements that are added to a figure that the template is applied to.  This is useful for styling, for example, any annotations, shapes, or images that will eventually be added to the figure.
 
@@ -244,7 +244,7 @@ fig.update_layout(template=draft_template)
 fig.show()
 ```
 
-### Customizing theme tuple elements in a figure
+#### Customizing theme tuple elements in a figure
 The previous section described how a template can be used to add default tuple element graph objects (e.g. annotations, shapes, or images) to a figure.  The properties of these default tuple elements can be customized from within the figure by adding an tuple element with a `templateitemname` property that matches the `name` property of the template object.
 
 Here is an example, using the same `draft_template` defined above, that customizes the watermark from within the figure to read "CONFIDENTIAL" rather than "DRAFT".
@@ -281,7 +281,7 @@ fig.update_layout(
 fig.show()
 ```
 
-### Registering themes as named templates
+#### Registering themes as named templates
 The examples above construct and configure a `Template` object and then pass that object as the template specification to graph object figures (as the `layout.template` property) or plotly express functions (as the `template` keyword argument).  It is also possible to register custom templates by name so that the name itself can be used to refer to the template.  To register a template, use dictionary-style assignment to associate the template object with a name in the `plotly.io.templates` configuration object.
 
 Here is an example of registering the draft watermark template from the previous sections as a template named `"draft"`.  Then a graph object figure is created with the draft template specified by name.
@@ -342,7 +342,7 @@ fig = go.Figure()
 fig.show()
 ```
 
-### Combining themes
+#### Combining themes
 You may have noticed that figures displayed with the custom templates defined above do not have the gray background and white gridlines that are part of the default styling of figures created with plotly.py.  The reason for this is that the default styling is specified in a template named `"plotly"`, and specifying a custom template overrides the default `"plotly"` template.
 
 If you want the styling of a custom template to be applied on top of the default styling of the `"plotly"` template, then you will need to combine the custom template with the `"plotly"` template. Multiple registered templates (whether built-in or user-defined) can be combined by specifying a template string that contains multiple template names joined on `"+"` characters.
@@ -410,7 +410,7 @@ fig.show()
 ```
 
 <!-- #region -->
-### Saving and distributing custom themes
+#### Saving and distributing custom themes
 The easiest way to save and distribute a custom template is to make a `*.py` file that creates and registers the template when it is imported.  Here is an example of the contents of a file called `my_themes.py` that creates and registers the `"draft"` template when it is imported
 
 **my_themes.py**
@@ -451,7 +451,7 @@ pio.templates.default = "draft"
 > Note: In order for the import to succeed, the `my_themes.py` file must be on Python's module search path. See https://docs.python.org/3/tutorial/modules.html#the-module-search-path for more information.
 <!-- #endregion -->
 
-### Examining built-in themes
+#### Examining built-in themes
 It may be useful to examine the contents and structure of the built-in templates when creating your own custom templates.  The `Template` graph object for a registered template can be loaded using dictionary-style key access on the `plotly.io.templates` configuration object.  Here is an example of loading the `Template` graph object for the `"plotly"` template, and then displaying the value of the template's `layout` property.
 
 ```python


### PR DESCRIPTION
Updates on the following new documentation pages to make H3 the largest heading level:
 - notebooks/creating-and-updating-figures.md
 - notebooks/getting-started.md
 - notebooks/renderers.md
 - notebooks/templates.md