### PR TITLE
remove from python index page after adding index

### DIFF
--- a/python/ohlc-charts.md
+++ b/python/ohlc-charts.md
@@ -21,7 +21,6 @@ jupyter:
     layout: user-guide
     name: OHLC Charts
     order: 1
-    page_type: example_index
     permalink: python/ohlc-charts/
     thumbnail: thumbnail/ohlc.jpg
     v4upgrade: true


### PR DESCRIPTION
As a part of https://github.com/plotly/documentation/pull/1338, this will line up the thumbnails in the main python index page after that is merged.

![Screenshot from 2019-09-13 11-56-35](https://user-images.githubusercontent.com/41019918/64876672-a7419700-d61d-11e9-85b3-84f86559d1e0.png)


Doc upgrade checklist is not applicable.
