### PR TITLE
Py mapbox area line

### DIFF
--- a/python/Line-on-Mapbox.md
+++ b/python/Line-on-Mapbox.md
@@ -13,7 +13,7 @@ jupyter:
     name: python3
   language_info:
     codemirror_mode:
-      name: ipython
+      name: ipython 
       version: 3
     file_extension: .py
     mimetype: text/x-python
@@ -22,19 +22,19 @@ jupyter:
     pygments_lexer: ipython3
     version: 3.7.3
   plotly:
-    description: How to make a Mapbox Choropleth Map of US Counties in Python with
+    description: How to draw a line on Map in Python with
       Plotly.
     display_as: maps
     has_thumbnail: true
     ipynb: ~notebook_demo/56
     language: python
     layout: user-guide
-    name: Mapbox Choropleth Maps
+    name: Lines on Maps
     order: 1
     page_type: example_index
-    permalink: python/mapbox-county-choropleth/
-    thumbnail: thumbnail/mapbox-choropleth.png
-    title: Python Mapbox Choropleth Maps | plotly
+    permalink: python/lines-on-maps/
+    thumbnail: thumbnail/fill-area.jpg
+    title: Lines on Maps | plotly
 ---
 
 
@@ -45,7 +45,8 @@ To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public 
 
 ### How to draw a Line on a Map 
 
-To draw a line on your map, you either can use [Scattermapbox](https://plot.ly/python/reference/#scattermapbox) or [scattergeo](https://plot.ly/python/reference/#scattergeo) trace type. Then . In this example uses scattermapbox and define the drawing [mode](https://plot.ly/python/reference/#scattermapbox-mode) to the combination of markers and line. 
+To draw a line on your map, you either can use [Scattermapbox](https://plot.ly/python/reference/#scattermapbox) or [scattergeo](https://plot.ly/python/reference/#scattergeo) trace type. This example uses scattermapbox and defines
+the drawing [mode](https://plot.ly/python/reference/#scattermapbox-mode) to the combination of markers and line. 
 
 ```python
 import plotly.graph_objects as go

--- a/python/Line-on-Mapbox.md
+++ b/python/Line-on-Mapbox.md
@@ -1,0 +1,163 @@
+---
+jupyter:
+  jupytext:
+    notebook_metadata_filter: all
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.1'
+      jupytext_version: 1.2.1
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.7.3
+  plotly:
+    description: How to make a Mapbox Choropleth Map of US Counties in Python with
+      Plotly.
+    display_as: maps
+    has_thumbnail: true
+    ipynb: ~notebook_demo/56
+    language: python
+    layout: user-guide
+    name: Mapbox Choropleth Maps
+    order: 1
+    page_type: example_index
+    permalink: python/mapbox-county-choropleth/
+    thumbnail: thumbnail/mapbox-choropleth.png
+    title: Python Mapbox Choropleth Maps | plotly
+---
+
+
+### Mapbox Access Token
+
+To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/python/mapbox-layers/) documentation for more information.
+
+
+### How to draw a Line on a Map 
+
+To draw a line on your map, you either can use [Scattermapbox](https://plot.ly/python/reference/#scattermapbox) or [scattergeo](https://plot.ly/python/reference/#scattergeo) trace type. Then . In this example uses scattermapbox and define the drawing [mode](https://plot.ly/python/reference/#scattermapbox-mode) to the combination of markers and line. 
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Scattermapbox(
+    mode = "markers+lines",
+    lon = [10, 20, 30], lat = [10, 20,30], 
+    marker = {'size': 10}))
+
+fig.add_trace(go.Scattermapbox(
+    mode = "markers+lines",      
+    lon = [-50, -60,40], lat = [30, 10, -20], 
+    marker = {'size': 10}))
+
+fig.update_layout(margin ={'l':0,'t':0,'b':0,'r':0},
+    mapbox = {'center': {'lon': 10, 'lat': 10},
+        'style': "stamen-terrain", 
+        'center': {'lon': -20, 'lat': -20}, 
+        'zoom': 1})
+
+fig.show()
+```
+
+### Set Marker Symbols 
+
+You can define a symbol on your map by setting [symbol](https://plot.ly/python/reference/#scattermapbox-marker-symbol) attribute. This attribute only works on mapbox tiles (not work on raster tiles): 
+- basic
+- streets
+- outdoors
+- light
+- dark
+- satellite
+- satellite-streets
+
+```python
+import plotly.graph_objects as go
+
+token = open(".mapbox_token").read() # you need your own token
+
+fig = go.Figure(go.Scattermapbox(
+    mode = "markers+text+lines",
+    lon = [-75, -80, -50], lat = [45, 20, -20], 
+    marker = {'size': 20, 'symbol': ["bus", "harbor", "airport"]},
+    text = ["Bus", "Harbor", "airport"],textposition = "bottom right"))
+
+fig.update_layout(
+    mapbox = {
+        'accesstoken': token,
+        'style': "outdoors", 'zoom': 0.7},
+    showlegend = False)
+
+fig.show()
+```
+### Contour Line on Glob
+This example uses [scattergeo](https://plot.ly/javascript/reference/#scattergeo) trace type to visualize the data as lines on a geographic map.
+
+```python
+import plotly.graph_objects as go
+import pandas as pd
+
+df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/globe_contours.csv')
+
+scl = ['blue', 'yellow', 'pink', \
+    'royalblue', 'fuchsia', 'blue', \
+    'brown', 'purple', 'orange']
+
+n_colors = len(scl)
+
+fig = go.Figure()
+
+for i, (lat, lon) in enumerate(zip(df.columns[::2], df.columns[1::2])):
+    fig.add_trace(go.Scattergeo(
+        lon = df[lon],
+        lat = df[lat],
+        mode = 'lines',
+        line = dict(width = 2, color = scl[i % n_colors]
+        )))
+
+fig.update_layout(
+    title_text = 'Contour lines over globe<br>(Click and drag to rotate)',
+    showlegend = False,
+    geo = dict(
+        showland = True,
+        showcountries = True,
+        showocean = True,
+        countrywidth = 0.5,
+        landcolor = 'orange',
+        lakecolor = 'cyan',
+        oceancolor = 'cyan',
+        projection = dict(
+            type = 'orthographic',
+            rotation = dict(
+                lon = -100,
+                lat = 40,
+                roll = 0
+            )
+        ),
+        lonaxis = dict(
+            showgrid = True,
+            gridcolor = 'black',
+            gridwidth = 0.5
+        ),
+        lataxis = dict(
+            showgrid = True,
+            gridcolor = 'black',
+            gridwidth = 0.5
+        )
+    )
+)
+
+fig.show()
+```
+
+#### Reference
+See https://plot.ly/python/reference/#choroplethmapbox for more information about mapbox and their attribute options.

--- a/python/Mapbox-area.md
+++ b/python/Mapbox-area.md
@@ -1,0 +1,142 @@
+---
+jupyter:
+  jupytext:
+    notebook_metadata_filter: all
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.1'
+      jupytext_version: 1.2.1
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.7.3
+  plotly:
+    description: How to make a Mapbox Choropleth Map of US Counties in Python with
+      Plotly.
+    display_as: maps
+    has_thumbnail: true
+    ipynb: ~notebook_demo/56
+    language: python
+    layout: user-guide
+    name: Mapbox Choropleth Maps
+    order: 1
+    page_type: example_index
+    permalink: python/mapbox-county-choropleth/
+    thumbnail: thumbnail/mapbox-choropleth.png
+    title: Python Mapbox Choropleth Maps | plotly
+---
+
+
+### Mapbox Access Token
+
+To plot on Mapbox maps with Plotly you *may* need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/python/mapbox-layers/) documentation for more information.
+
+
+### How to Show an Area on a Map 
+
+There are three different ways to show an area in a mapbox: 
+- Set `fill` attribute to 'toself' 
+- Define the corresponding geojson
+- Use the new trace type: [Choroplethmapbox](https://plot.ly/python/mapbox-county-choropleth/) for mapbox cases, or [Choropleth](https://plot.ly/python/choropleth-maps/) trace for non-mapbox ones.
+
+The following example uses `Scattermapbox` and sets `fill = 'toself'` 
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Scattermapbox(
+    fill = "toself", 
+    lon = [-74, -70, -70, -74], lat = [47, 47, 45, 45],
+    marker = { 'size': 10, 'color': "orange" }))
+
+fig.update_layout(
+    mapbox = {
+        'style': "stamen-terrain", 
+        'center': {'lon': -73, 'lat': 46 }, 
+        'zoom': 5}, 
+    showlegend = False)
+        
+fig.show()
+```
+
+### Provide Gaps on Map
+
+The following example shows how to use missing values in your data to provide gap in your graph. To ignore the gap on your plot, take benefit of [connectorgaps](https://plot.ly/python/reference/#scattermapbox-connectgaps) attribute.
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Scattermapbox(
+    mode = "lines", fill = "toself",
+    lon = [-10, -10, 8, 8, None, 30, 30, 50, 50, None, 100, 100, 80, 80], lat = [30, 6, 6, 30, None, 20, 30, 30, 20, None, 40, 50, 50, 40]))
+
+fig.update_layout(
+    mapbox = {'style': "stamen-terrain", 'center': {'lon': 30, 'lat': 30}, 'zoom': 2},
+    showlegend = False,
+    margin = {'l':0, 'r':0, 'b':0, 't':0})
+
+fig.show()
+```
+
+### Use the Coresponding Geojson
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Scattermapbox(
+    mode = "markers",
+    lon = [-73.605], lat = [45.51],
+    marker = {'size': 20, 'color': ["cyan"]}))
+
+fig.update_layout(
+    mapbox = {
+        'style': "stamen-terrain",
+        'center': { 'lon': -73.6, 'lat': 45.5},
+        'zoom': 12, 'layers': [{
+            'source': {
+                'type': "FeatureCollection",
+                'features': [{
+                    'type': "Feature",
+                    'geometry': {
+                        'type': "MultiPolygon",
+                        'coordinates': [[[
+                            [-73.606352888, 45.507489991], [-73.606133883, 45.50687600],
+                            [-73.605905904, 45.506773980], [-73.603533905, 45.505698946],
+                            [-73.602475870, 45.506856969], [-73.600031904, 45.505696003],
+                            [-73.599379992, 45.505389066], [-73.599119902, 45.505632008],
+                            [-73.598896977, 45.505514039], [-73.598783894, 45.505617001],
+                            [-73.591308727, 45.516246185], [-73.591380782, 45.516280145],
+                            [-73.596778656, 45.518690062], [-73.602796770, 45.521348046],
+                            [-73.612239983, 45.525564037], [-73.612422919, 45.525642061],
+                            [-73.617229085, 45.527751983], [-73.617279234, 45.527774160],
+                            [-73.617304713, 45.527741334], [-73.617492052, 45.527498362],
+                            [-73.617533258, 45.527512253], [-73.618074188, 45.526759105],
+                            [-73.618271651, 45.526500673], [-73.618446320, 45.526287943],
+                            [-73.618968507, 45.525698560], [-73.619388002, 45.525216750],
+                            [-73.619532966, 45.525064183], [-73.619686662, 45.524889290],
+                            [-73.619787038, 45.524770086], [-73.619925742, 45.524584939],
+                            [-73.619954486, 45.524557690], [-73.620122362, 45.524377961],
+                            [-73.620201713, 45.524298907], [-73.620775593, 45.523650879]
+                        ]]]
+                    }
+                }]
+            },
+            'type': "fill", 'below': "traces", 'color': "royalblue"}]},
+    margin = {'l':0, 'r':0, 'b':0, 't':0})
+
+fig.show()
+```
+
+#### Reference
+See https://plot.ly/python/reference/#choroplethmapbox for more information about mapbox and their attribute options.

--- a/python/Mapbox-area.md
+++ b/python/Mapbox-area.md
@@ -22,18 +22,18 @@ jupyter:
     pygments_lexer: ipython3
     version: 3.7.3
   plotly:
-    description: How to make a Mapbox Choropleth Map of US Counties in Python with
+    description: How to make an area on Map in Python with
       Plotly.
     display_as: maps
     has_thumbnail: true
     ipynb: ~notebook_demo/56
     language: python
     layout: user-guide
-    name: Mapbox Choropleth Maps
+    name: Filled Area on Maps
     order: 1
     page_type: example_index
-    permalink: python/mapbox-county-choropleth/
-    thumbnail: thumbnail/mapbox-choropleth.png
+    permalink: python/filled-area-on-mapbox/
+    thumbnail: thumbnail/area.jpg
     title: Python Mapbox Choropleth Maps | plotly
 ---
 


### PR DESCRIPTION
Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
