### PR TITLE
Update `graph_objects` to `graph_objs`

### DIFF
--- a/python/figurewidget.md
+++ b/python/figurewidget.md
@@ -41,7 +41,7 @@ jupyter:
 Create an empty FigureWidget and then view it.
 
 ```python
-import plotly.graph_objects as go
+import plotly.graph_objs as go
 
 f = go.FigureWidget()
 f
@@ -91,7 +91,7 @@ f.layout.title.text = 'This is a new title'
 A standard `Figure` object can be passed to the `FigureWidget` constructor.
 
 ```python
-import plotly.graph_objects as go
+import plotly.graph_objs as go
 
 trace = go.Heatmap(z=[[1, 20, 30, 50, 1], [20, 1, 60, 80, 30], [30, 60, 1, -10, 20]],
                    x=['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],


### PR DESCRIPTION
Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
