### PR TITLE
upgrading sunburst

### DIFF
--- a/python/sunburst-charts.md
+++ b/python/sunburst-charts.md
@@ -26,53 +26,27 @@ jupyter:
     title: Sunburst in Python | plotly
 ---
 
-#### New to Plotly?
-Plotly's Python library is free and open source! [Get started](https://plot.ly/python/getting-started/) by downloading the client and [reading the primer](https://plot.ly/python/getting-started/).
-<br>You can set up Plotly to work in [online](https://plot.ly/python/getting-started/#initialization-for-online-plotting) or [offline](https://plot.ly/python/getting-started/#initialization-for-offline-plotting) mode, or in [jupyter notebooks](https://plot.ly/python/getting-started/#start-plotting-online).
-<br>We also have a quick-reference [cheatsheet](https://images.plot.ly/plotly-documentation/images/python_cheat_sheet.pdf) (new!) to help you get started!
-
-
-
-#### Version Check
-Note: Sunburst Charts are available in version <b>3.8+</b><br>
-Run  `pip install plotly --upgrade` to update your Plotly version
-
-
-
-```python
-import plotly
-plotly.__version__
-```
-
 ### Basic Sunburst Plot ###
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-trace = go.Sunburst(
+fig =go.Figure(go.Sunburst(
     labels=["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"],
     parents=["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve" ],
     values=[10, 14, 12, 10, 2, 6, 6, 4, 4],
-    outsidetextfont = {"size": 20, "color": "#377eb8"},
-    marker = {"line": {"width": 2}},
-)
+))
+fig.update_layout(margin = dict(t=0, l=0, r=0, b=0))
 
-layout = go.Layout(
-    margin = go.layout.Margin(t=0, l=0, r=0, b=0)
-)
-
-py.iplot(go.Figure([trace], layout), filename='basic_sunburst_chart')
+fig.show()
 ```
 
 ### Sunburst with Repeated Labels
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
-
-trace = go.Sunburst(
+fig =go.Figure(go.Sunburst(
  ids=[
     "North America", "Europe", "Australia", "North America - Football", "Soccer",
     "North America - Rugby", "Europe - Football", "Rugby",
@@ -92,86 +66,52 @@ trace = go.Sunburst(
     "Australia - Football", "Australia - Football", "Australia - Rugby",
     "Australia - Rugby"
   ],
-  outsidetextfont={"size": 20, "color": "#377eb8"},
-  leaf={"opacity": 0.4},
-  marker={"line": {"width": 2}}
-)
+))
+fig.update_layout(margin = dict(t=0, l=0, r=0, b=0))
 
-layout = go.Layout(
-    margin = go.layout.Margin(t=0, l=0, r=0, b=0),
-    sunburstcolorway=["#636efa","#ef553b","#00cc96"]
-)
-
-fig = go.Figure([trace], layout)
-
-py.iplot(fig, filename='repeated_labels_sunburst')
+fig.show()
 ```
 
 ### Large Number of Slices
+
 This example uses a [plotly grid attribute](https://plot.ly/python/reference/#layout-grid) for the suplots. Reference the row and column destination using the [domain](https://plot.ly/python/reference/#sunburst-domain) attribute.
 
 ```python
-import plotly.plotly as py
-import plotly.graph_objs as go
+import plotly.graph_objects as go
 
 import pandas as pd
 
 df1 = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/718417069ead87650b90472464c7565dc8c2cb1c/sunburst-coffee-flavors-complete.csv')
 df2 = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/718417069ead87650b90472464c7565dc8c2cb1c/coffee-flavors.csv')
 
-trace1 = go.Sunburst(
+fig = go.Figure()
+
+fig.add_trace(go.Sunburst(
     ids=df1.ids,
     labels=df1.labels,
     parents=df1.parents,
     domain=dict(column=0)
-)
+))
 
-trace2 = go.Sunburst(
+fig.add_trace(go.Sunburst(
     ids=df2.ids,
     labels=df2.labels,
     parents=df2.parents,
     domain=dict(column=1),
     maxdepth=2
-)
+))
 
-layout = go.Layout(
-    grid=go.layout.Grid(columns=2, rows=1),
-    margin = go.layout.Margin(t=0, l=0, r=0, b=0),
+fig.update_layout(
+    grid= dict(columns=2, rows=1),
+    margin = dict(t=0, l=0, r=0, b=0),
     sunburstcolorway=[
     "#636efa","#EF553B","#00cc96","#ab63fa","#19d3f3",
-    "#e763fa", "#FECB52","#FFA15A","#FF6692","#B6E880"
-  ],
+    "#e763fa", "#FECB52","#FFA15A","#FF6692","#B6E880"],
     extendsunburstcolors=True
 )
 
-data = [trace1, trace2]
-
-fig = go.Figure(data, layout)
-
-py.iplot(fig, filename='large_number_of_slices')
+fig.show()
 ```
 
 #### Reference
 See https://plot.ly/python/reference/#sunburst for more information and chart attribute options!
-
-```python
-from IPython.display import display, HTML
-
-display(HTML('<link href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Inconsolata|Ubuntu+Mono:400,700" rel="stylesheet" type="text/css" />'))
-display(HTML('<link rel="stylesheet" type="text/css" href="http://help.plot.ly/documentation/all_static/css/ipython-notebook-custom.css">'))
-
-! pip install git+https://github.com/plotly/publisher.git --upgrade
-import publisher
-publisher.publish(
-    'sunburst-charts.ipynb', 'python/sunburst-charts/', 'Sunburst Charts',
-    'How to make Sunburst Charts.',
-    title= 'Sunburst in Python | plotly',
-    has_thumbnail='true', thumbnail='thumbnail/sunburst.gif',
-    language='python',
-    display_as='basic', order=6.1,
-    ipynb='~notebook_demo/274/')
-```
-
-```python
-
-```

--- a/python/sunburst-charts.md
+++ b/python/sunburst-charts.md
@@ -11,6 +11,16 @@ jupyter:
     display_name: Python 3
     language: python
     name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.6.8
   plotly:
     description: How to make Sunburst Charts.
     display_as: basic
@@ -103,11 +113,7 @@ fig.add_trace(go.Sunburst(
 
 fig.update_layout(
     grid= dict(columns=2, rows=1),
-    margin = dict(t=0, l=0, r=0, b=0),
-    sunburstcolorway=[
-    "#636efa","#EF553B","#00cc96","#ab63fa","#19d3f3",
-    "#e763fa", "#FECB52","#FFA15A","#FF6692","#B6E880"],
-    extendsunburstcolors=True
+    margin = dict(t=0, l=0, r=0, b=0)
 )
 
 fig.show()


### PR DESCRIPTION
Doc upgrade checklist:

- [x] random seed is set if using random data
- [x] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [x] old boilerplate at top and bottom of file has been removed
- [x] Every example is independently runnable and is optimized for short line count
- [x] no more `plot()` or `iplot()`
- [x] `graph_objs` has been renamed to `graph_objects`
- [x] `fig = <something>` call is high up in each example
- [x] minimal creation of intermediate `trace` objects
- [x] liberal use of `add_trace` and `update_layout`
- [x] `fig.show()` at the end of each example
- [x] `px` example at the top if appropriate
- [x] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
