### PR TITLE
Add detailed explanations to Sunburst basic example

### DIFF
--- a/python/2D-Histogram.md
+++ b/python/2D-Histogram.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/24
     language: python
-    layout: user-guide
+    layout: base
     name: 2D Histograms
     order: 6
     page_type: u-guide

--- a/python/2d-histogram-contour.md
+++ b/python/2d-histogram-contour.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/199
     language: python
-    layout: user-guide
+    layout: base
     name: 2D Histogram Contour
     order: 30
     page_type: u-guide

--- a/python/3d-axes.md
+++ b/python/3d-axes.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/96
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Axes
     order: 0.101
     page_type: example_index

--- a/python/3d-bubble-charts.md
+++ b/python/3d-bubble-charts.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/62
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Bubble Charts
     order: 2
     page_type: u-guide

--- a/python/3d-camera-controls.md
+++ b/python/3d-camera-controls.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/78
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Camera Controls
     order: 0.108
     permalink: python/3d-camera-controls/

--- a/python/3d-isosurface-plots.md
+++ b/python/3d-isosurface-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/272
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Isosurface Plots
     order: 12.1
     page_type: u-guide

--- a/python/3d-line-plots.md
+++ b/python/3d-line-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/63
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Line Plots
     order: 3
     page_type: u-guide

--- a/python/3d-mesh.md
+++ b/python/3d-mesh.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/67
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Mesh Plots
     order: 7
     page_type: u-guide

--- a/python/3d-scatter-plots.md
+++ b/python/3d-scatter-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/61
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Scatter Plots
     order: 1
     page_type: example_index

--- a/python/3d-subplots.md
+++ b/python/3d-subplots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/75
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Subplots
     order: 0.104
     page_type: u-guide

--- a/python/3d-surface-coloring.md
+++ b/python/3d-surface-coloring.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/76
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Surface Coloring
     order: 7
     permalink: python/3d-surface-coloring/

--- a/python/3d-surface-plots.md
+++ b/python/3d-surface-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/66
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Surface Plots
     order: 6
     page_type: example_index

--- a/python/3d-surface-plots.md
+++ b/python/3d-surface-plots.md
@@ -28,7 +28,7 @@ jupyter:
     ipynb: ~notebook_demo/66
     language: python
     layout: user-guide
-    name: 3D Surface Plots in Python
+    name: 3D Surface Plots
     order: 6
     page_type: example_index
     permalink: python/3d-surface-plots/

--- a/python/3d-volume.md
+++ b/python/3d-volume.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: 3d_charts
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Volume Plots
     order: 12.2
     page_type: u-guide

--- a/python/aggregations.md
+++ b/python/aggregations.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/192
     language: python
-    layout: user-guide
+    layout: base
     name: Aggregations
     order: 3
     page_type: example_index

--- a/python/animations.md
+++ b/python/animations.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/131
     language: python
-    layout: user-guide
+    layout: base
     name: Intro to Animations
     order: 1
     page_type: example_index

--- a/python/annotated_heatmap.md
+++ b/python/annotated_heatmap.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/35
     language: python
-    layout: user-guide
+    layout: base
     name: Annotated Heatmaps
     order: 4
     page_type: u-guide

--- a/python/axes.md
+++ b/python/axes.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/95
     language: python
-    layout: user-guide
+    layout: base
     name: Axes
     order: 12
     permalink: python/axes/

--- a/python/bar-charts.md
+++ b/python/bar-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/186
     language: python
-    layout: user-guide
+    layout: base
     name: Bar Charts
     order: 4
     page_type: example_index

--- a/python/box-plots.md
+++ b/python/box-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/20
     language: python
-    layout: user-guide
+    layout: base
     name: Box Plots
     order: 3
     page_type: example_index

--- a/python/bubble-charts.md
+++ b/python/bubble-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/1/new-to-plotly-plotlys-python-library-i
     language: python
-    layout: user-guide
+    layout: base
     name: Bubble Charts
     order: 3
     page_type: u-guide

--- a/python/bubble-maps.md
+++ b/python/bubble-maps.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: maps
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Bubble Maps
     order: 2
     page_type: example_index

--- a/python/bullet-charts.md
+++ b/python/bullet-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/11
     language: python
-    layout: user-guide
+    layout: base
     name: Bullet Charts
     order: 7
     page_type: u-guide

--- a/python/candlestick-charts.md
+++ b/python/candlestick-charts.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/275
     language: python
-    layout: user-guide
+    layout: base
     name: Candlestick Charts
     order: 2
     page_type: example_index

--- a/python/carpet-contour.md
+++ b/python/carpet-contour.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/145
     language: python
-    layout: user-guide
+    layout: base
     name: Carpet Contour Plot
     order: 27
     page_type: u-guide

--- a/python/carpet-plot.md
+++ b/python/carpet-plot.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/144
     language: python
-    layout: user-guide
+    layout: base
     name: Carpet Plots
     order: 26
     page_type: u-guide

--- a/python/carpet-scatter.md
+++ b/python/carpet-scatter.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/146
     language: python
-    layout: user-guide
+    layout: base
     name: Carpet Scatter Plot
     order: 28
     page_type: u-guide

--- a/python/choropleth-maps.md
+++ b/python/choropleth-maps.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/55
     language: python
-    layout: user-guide
+    layout: base
     name: Choropleth Maps
     order: 5
     page_type: u-guide

--- a/python/click-events.md
+++ b/python/click-events.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/240
     language: python
-    layout: user-guide
+    layout: base
     name: Click Events
     order: 24
     page_type: example_index

--- a/python/colorscales.md
+++ b/python/colorscales.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/187
     language: python
-    layout: user-guide
+    layout: base
     name: Colorscales
     order: 22
     permalink: python/colorscales/

--- a/python/compare-webgl-svg.md
+++ b/python/compare-webgl-svg.md
@@ -26,7 +26,7 @@ jupyter:
       with Plotly.
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Comparing WebGL vs SVG
     page_type: example_index
     permalink: python/compare-webgl-svg/

--- a/python/cone-plot.md
+++ b/python/cone-plot.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/206
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Cone Plots
     order: 20
     page_type: u-guide

--- a/python/configuration-options.md
+++ b/python/configuration-options.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/97
     language: python
-    layout: user-guide
+    layout: base
     name: Configuration
     order: 7
     page_type: u-guide

--- a/python/contour-plots.md
+++ b/python/contour-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/185
     language: python
-    layout: user-guide
+    layout: base
     name: Contour Plots
     order: 2
     page_type: example_index

--- a/python/county-choropleth.md
+++ b/python/county-choropleth.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/212
     language: python
-    layout: user-guide
+    layout: base
     name: USA County Choropleth Maps
     order: 20
     page_type: u-guide

--- a/python/creating-and-updating-figures.md
+++ b/python/creating-and-updating-figures.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: file_settings
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Creating and Updating Figures
     page_type: example_index
     permalink: python/creating-and-updating-figures/

--- a/python/custom-buttons.md
+++ b/python/custom-buttons.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: controls
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Custom Buttons
     order: 1
     page_type: example_index

--- a/python/dendrogram.md
+++ b/python/dendrogram.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/262
     language: python
-    layout: user-guide
+    layout: base
     name: Dendrograms
     order: 6
     page_type: u-guide

--- a/python/distplot.md
+++ b/python/distplot.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/23
     language: python
-    layout: user-guide
+    layout: base
     name: Distplots
     order: 5
     page_type: example_index

--- a/python/dot-plots.md
+++ b/python/dot-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/2
     language: python
-    layout: user-guide
+    layout: base
     name: Dot Plots
     order: 3.1
     page_type: u-guide

--- a/python/dropdowns.md
+++ b/python/dropdowns.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/85
     language: python
-    layout: user-guide
+    layout: base
     name: Dropdown Menus
     order: 2
     page_type: example_index

--- a/python/error-bars.md
+++ b/python/error-bars.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/18
     language: python
-    layout: user-guide
+    layout: base
     name: Error Bars
     order: 1
     page_type: example_index

--- a/python/facet-plots.md
+++ b/python/facet-plots.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: statistical
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Facet and Trellis Plots
     order: 10.2
     page_type: u-guide

--- a/python/figure-factory-subplots.md
+++ b/python/figure-factory-subplots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~PythonPlotBot/1828
     language: python
-    layout: user-guide
+    layout: base
     name: Figure Factory Subplots
     order: 10
     page_type: u-guide

--- a/python/figure-labels.md
+++ b/python/figure-labels.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/271
     language: python
-    layout: user-guide
+    layout: base
     name: Setting the Title, Legend Entries, and Axis Titles
     order: 11
     permalink: python/figure-labels/

--- a/python/figurewidget-app.md
+++ b/python/figurewidget-app.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/231
     language: python
-    layout: user-guide
+    layout: base
     name: Interactive Data Analysis with FigureWidget ipywidgets
     order: 23
     page_type: example_index

--- a/python/figurewidget.md
+++ b/python/figurewidget.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/235
     language: python
-    layout: user-guide
+    layout: base
     name: Plotly FigureWidget Overview
     order: 0
     page_type: example_index

--- a/python/filled-area-plots.md
+++ b/python/filled-area-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/8
     language: python
-    layout: user-guide
+    layout: base
     name: Filled Area Plots
     order: 3.5
     page_type: u-guide

--- a/python/filter.md
+++ b/python/filter.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/195
     language: python
-    layout: user-guide
+    layout: base
     name: Filter
     order: 1
     page_type: example_index

--- a/python/funnel-charts.md
+++ b/python/funnel-charts.md
@@ -22,7 +22,7 @@ jupyter:
     display_as: financial
     order: 4
     ipynb: ~notebook_demo/293
-    layout: user-guide
+    layout: base
     page_type: example_index
 ---
 

--- a/python/gantt.md
+++ b/python/gantt.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/6
     language: python
-    layout: user-guide
+    layout: base
     name: Gantt Charts
     order: 5.5
     page_type: u-guide

--- a/python/gauge-charts.md
+++ b/python/gauge-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/11
     language: python
-    layout: user-guide
+    layout: base
     name: Gauge Charts
     order: 6
     page_type: u-guide

--- a/python/getting-started.md
+++ b/python/getting-started.md
@@ -26,7 +26,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/123/installation
     language: python
-    layout: getstart
+    layout: base
     name: Getting Started with Plotly
     page_type: u-guide
     permalink: python/getting-started/

--- a/python/getting-started.md
+++ b/python/getting-started.md
@@ -27,7 +27,7 @@ jupyter:
     ipynb: ~notebook_demo/123/installation
     language: python
     layout: getstart
-    name: Getting Started with Plotly for Python
+    name: Getting Started with Plotly
     page_type: u-guide
     permalink: python/getting-started/
     redirect_from: python/getting_started/

--- a/python/graphing-multiple-chart-types.md
+++ b/python/graphing-multiple-chart-types.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: file_settings
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Multiple Chart Types
     order: 16
     page_type: u-guide

--- a/python/group-by.md
+++ b/python/group-by.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/194
     language: python
-    layout: user-guide
+    layout: base
     name: Group By
     order: 2
     page_type: example_index

--- a/python/heatmaps.md
+++ b/python/heatmaps.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/33
     language: python
-    layout: user-guide
+    layout: base
     name: Heatmaps
     order: 3
     page_type: example_index

--- a/python/histograms.md
+++ b/python/histograms.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/22
     language: python
-    layout: user-guide
+    layout: base
     name: Histograms
     order: 4
     page_type: example_index

--- a/python/horizontal-bar-charts.md
+++ b/python/horizontal-bar-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/5
     language: python
-    layout: user-guide
+    layout: base
     name: Horizontal Bar Charts
     order: 5
     page_type: u-guide

--- a/python/horizontal-legend.md
+++ b/python/horizontal-legend.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/94
     language: python
-    layout: user-guide
+    layout: base
     name: Horizontal Legends
     order: 12
     page_type: example_index

--- a/python/hover-text-and-formatting.md
+++ b/python/hover-text-and-formatting.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/198
     language: python
-    layout: user-guide
+    layout: base
     name: Hover Text and Formatting
     order: 30.5
     permalink: python/hover-text-and-formatting/

--- a/python/images.md
+++ b/python/images.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/216
     language: python
-    layout: user-guide
+    layout: base
     name: Images
     order: 31
     permalink: python/images/

--- a/python/indicator.md
+++ b/python/indicator.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/11
     language: python
-    layout: user-guide
+    layout: base
     name: Indicators
     order: 5
     page_type: u-guide

--- a/python/ipython-vs-python.md
+++ b/python/ipython-vs-python.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/17
     language: python
-    layout: user-guide
+    layout: base
     name: IPython vs Python
     order: 41
     permalink: python/ipython-vs-python/

--- a/python/jupyter-lab-tools.md
+++ b/python/jupyter-lab-tools.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: chart_events
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Jupyter Lab with FigureWidget
     order: 2
     permalink: python/jupyter-lab-tools/

--- a/python/legend.md
+++ b/python/legend.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/14
     language: python
-    layout: user-guide
+    layout: base
     name: Legends
     order: 13
     permalink: python/legend/

--- a/python/line-and-scatter.md
+++ b/python/line-and-scatter.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/2
     language: python
-    layout: user-guide
+    layout: base
     name: Scatter Plots
     order: 2
     page_type: example_index

--- a/python/line-charts.md
+++ b/python/line-charts.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/3
     language: python
-    layout: user-guide
+    layout: base
     name: Line Charts
     order: 3.3
     page_type: example_index

--- a/python/lines-on-maps.md
+++ b/python/lines-on-maps.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/58
     language: python
-    layout: user-guide
+    layout: base
     name: Lines on Maps
     order: 4
     page_type: example_index

--- a/python/log-plot.md
+++ b/python/log-plot.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/31
     language: python
-    layout: user-guide
+    layout: base
     name: Log Plots
     order: 1
     permalink: python/log-plot/

--- a/python/map-subplots-and-small-multiples.md
+++ b/python/map-subplots-and-small-multiples.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/59
     language: python
-    layout: user-guide
+    layout: base
     name: Map Subplots
     order: 5
     page_type: example_index

--- a/python/mapbox-county-choropleth.md
+++ b/python/mapbox-county-choropleth.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/56
     language: python
-    layout: user-guide
+    layout: base
     name: Mapbox Choropleth Maps
     order: 1
     page_type: example_index

--- a/python/mapbox-density-heatmaps.md
+++ b/python/mapbox-density-heatmaps.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/56
     language: python
-    layout: user-guide
+    layout: base
     name: Mapbox Density Heatmap
     order: 3
     page_type: example_index

--- a/python/mapbox-layers.md
+++ b/python/mapbox-layers.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/261
     language: python
-    layout: user-guide
+    layout: base
     name: Mapbox Map Layers
     order: 7
     page_type: u-guide

--- a/python/marker-style.md
+++ b/python/marker-style.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/203
     language: python
-    layout: user-guide
+    layout: base
     name: Styling Markers
     order: 21
     permalink: python/marker-style/

--- a/python/mixed-subplots.md
+++ b/python/mixed-subplots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/132
     language: python
-    layout: user-guide
+    layout: base
     name: Mixed Subplots
     order: 5
     page_type: example_index

--- a/python/multiple-axes.md
+++ b/python/multiple-axes.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/270
     language: python
-    layout: user-guide
+    layout: base
     name: Multiple Axes
     order: 14
     permalink: python/multiple-axes/

--- a/python/multiple-transforms.md
+++ b/python/multiple-transforms.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/193
     language: python
-    layout: user-guide
+    layout: base
     name: Multiple Transforms
     order: 4
     page_type: example_index

--- a/python/network-graphs.md
+++ b/python/network-graphs.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/223
     language: python
-    layout: user-guide
+    layout: base
     name: Network Graphs
     order: 14
     page_type: u-guide

--- a/python/ohlc-charts.md
+++ b/python/ohlc-charts.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/53
     language: python
-    layout: user-guide
+    layout: base
     name: OHLC Charts
     order: 1
     permalink: python/ohlc-charts/

--- a/python/orca-management.md
+++ b/python/orca-management.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/253
     language: python
-    layout: user-guide
+    layout: base
     name: Orca Management
     order: 1.5
     permalink: python/orca-management/

--- a/python/parallel-categories-diagram.md
+++ b/python/parallel-categories-diagram.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/258
     language: python
-    layout: user-guide
+    layout: base
     name: Parallel Categories Diagram
     order: 10.3
     page_type: u-guide

--- a/python/parallel-coordinates-plot.md
+++ b/python/parallel-coordinates-plot.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/142
     language: python
-    layout: user-guide
+    layout: base
     name: Parallel Coordinates Plot
     order: 11.5
     page_type: u-guide

--- a/python/peak-finding.md
+++ b/python/peak-finding.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/120
     language: python
-    layout: user-guide
+    layout: base
     name: Peak Finding
     order: 3
     page_type: example_index

--- a/python/pie-charts.md
+++ b/python/pie-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/7/
     language: python
-    layout: user-guide
+    layout: base
     name: Pie Charts
     order: 6
     page_type: example_index

--- a/python/plot-data-from-csv.md
+++ b/python/plot-data-from-csv.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/84
     language: python
-    layout: user-guide
+    layout: base
     name: Plot CSV Data
     order: 1
     page_type: example_index

--- a/python/plotly-express.md
+++ b/python/plotly-express.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/252
     language: python
-    layout: user-guide
+    layout: base
     name: Plotly Express
     order: 1
     page_type: example_index

--- a/python/polar-chart.md
+++ b/python/polar-chart.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/200
     language: python
-    layout: user-guide
+    layout: base
     name: Polar Charts
     order: 29
     page_type: u-guide

--- a/python/quiver-plots.md
+++ b/python/quiver-plots.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/42
     language: python
-    layout: user-guide
+    layout: base
     name: Quiver Plots
     order: 12
     permalink: python/quiver-plots/

--- a/python/radar-chart.md
+++ b/python/radar-chart.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/202
     language: python
-    layout: user-guide
+    layout: base
     name: Radar Charts
     order: 30
     page_type: u-guide

--- a/python/random-walk.md
+++ b/python/random-walk.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/114
     language: python
-    layout: user-guide
+    layout: base
     name: Random Walk
     order: 10
     page_type: example_index

--- a/python/range-slider.md
+++ b/python/range-slider.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/211
     language: python
-    layout: user-guide
+    layout: base
     name: Range Slider and Selector
     order: 3
     page_type: example_index

--- a/python/renderers.md
+++ b/python/renderers.md
@@ -29,7 +29,7 @@ jupyter:
     language: python
     name: Displaying Figures
     page_type: example_index
-    layout: user-guide
+    layout: base
     permalink: python/renderers/
     redirect_from: python/offline/
     thumbnail: thumbnail/displaying-figures.png

--- a/python/sankey-diagram.md
+++ b/python/sankey-diagram.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/151
     language: python
-    layout: user-guide
+    layout: base
     name: Sankey Diagram
     order: 11
     page_type: u-guide

--- a/python/scatter-plots-on-maps.md
+++ b/python/scatter-plots-on-maps.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/57
     language: python
-    layout: user-guide
+    layout: base
     name: Scatter Plots on Maps
     order: 2
     page_type: u-guide

--- a/python/scattermapbox.md
+++ b/python/scattermapbox.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/261
     language: python
-    layout: user-guide
+    layout: base
     mapbox_access_token: pk.eyJ1IjoicHJpeWF0aGFyc2FuIiwiYSI6ImNqbGRyMGQ5YTBhcmkzcXF6YWZldnVvZXoifQ.sN7gyyHTIq1BSfHQRBZdHA
     name: Scatter Plots on Mapbox
     order: 8

--- a/python/setting-graph-size.md
+++ b/python/setting-graph-size.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/133
     language: python
-    layout: user-guide
+    layout: base
     name: Setting Graph Size
     order: 2
     permalink: python/setting-graph-size/

--- a/python/shapes.md
+++ b/python/shapes.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/14
     language: python
-    layout: user-guide
+    layout: base
     name: Shapes
     order: 32
     permalink: python/shapes/

--- a/python/sliders.md
+++ b/python/sliders.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/85
     language: python
-    layout: user-guide
+    layout: base
     name: Sliders
     order: 1.5
     page_type: example_index

--- a/python/smoothing.md
+++ b/python/smoothing.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: signal-analysis
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Smoothing
     order: 1
     page_type: example_index

--- a/python/splom.md
+++ b/python/splom.md
@@ -27,7 +27,7 @@ jupyter:
     display_as: statistical
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Scatterplot Matrix
     order: 10.2
     page_type: u-guide

--- a/python/static-image-export.md
+++ b/python/static-image-export.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/252
     language: python
-    layout: user-guide
+    layout: base
     name: Static Image Export
     order: 1
     page_type: u-guide

--- a/python/streamline-plots.md
+++ b/python/streamline-plots.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/43
     language: python
-    layout: user-guide
+    layout: base
     name: Streamline Plots
     order: 13
     permalink: python/streamline-plots/

--- a/python/streamtube-plot.md
+++ b/python/streamtube-plot.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/207
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Streamtube Plots
     order: 21
     page_type: u-guide

--- a/python/subplots.md
+++ b/python/subplots.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/269
     language: python
-    layout: user-guide
+    layout: base
     name: Subplots
     order: 15
     page_type: u-guide

--- a/python/sunburst-charts.md
+++ b/python/sunburst-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/274/
     language: python
-    layout: user-guide
+    layout: base
     name: Sunburst Charts
     order: 6.1
     page_type: u-guide

--- a/python/sunburst-charts.md
+++ b/python/sunburst-charts.md
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.8
+    version: 3.7.3
   plotly:
     description: How to make Sunburst Charts.
     display_as: basic
@@ -37,14 +37,13 @@ jupyter:
 ---
 
 ### Basic Sunburst Plot ###
-Sunburst plot visualizes hierarchal data spanning outward radially from root to leaves. The sunburst sectors are determined by the entries in "labels" and in "parents". The root starts from the center and childs are added to the outer rings.
+Sunburst plot visualizes hierarchical data spanning outwards radially from root to leaves. The sunburst sectors are determined by the entries in "labels" and in "parents". The root starts from the center and children are added to the outer rings.
 
-Attributes used:
-1. **labels**: sets the labels of each of the sunburst sectors.
-2. **parents**: sets the parent sectors for each of the sunburst sectors. Empty string items '' are understood to reference the root node in the hierarchy. In this case, "Eve" is the root in the sunburst plot.
-3. **values**: sets the values associated with each of the sunburst sectors. It Uses with `branchvalues` to determine how the values are summed. See "Branchvalues" section below explains the details.
+Main arguments:
+1. **labels**: sets the labels of sunburst sectors.
+2. **parents**: sets the parent sectors of sunburst sectors. An empty string '' is used for the root node in the hierarchy. In this example, the root is "Eve".
+3. **values**: sets the values associated with sunburst sectors, determining their width (See the "Branchvalues" section below for different modes for setting the width).
 
-update_layout() method is used to update the figure's margin. You can update more layouts. See [plotly update layout method](https://plot.ly/python/creating-and-updating-figures/)
 
 ```python
 import plotly.graph_objects as go
@@ -54,6 +53,8 @@ fig =go.Figure(go.Sunburst(
     parents=["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve" ],
     values=[10, 14, 12, 10, 2, 6, 6, 4, 4],
 ))
+# Update layout for tight margin
+# See https://plot.ly/python/creating-and-updating-figures/
 fig.update_layout(margin = dict(t=0, l=0, r=0, b=0))
 
 fig.show()

--- a/python/table-subplots.md
+++ b/python/table-subplots.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: multiple_axes
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Table and Chart Subplots
     order: 11
     page_type: example_index

--- a/python/table.md
+++ b/python/table.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/197
     language: python
-    layout: user-guide
+    layout: base
     name: Tables
     order: 7
     page_type: u-guide

--- a/python/templates.md
+++ b/python/templates.md
@@ -29,7 +29,7 @@ jupyter:
     has_thumbnail: true
     name: Theming and templates
     page_type: u-guide
-    layout: user-guide
+    layout: base
     permalink: python/templates/
     thumbnail: thumbnail/theming-and-templates.png
     title: Theming and templates | plotly

--- a/python/ternary-contour.md
+++ b/python/ternary-contour.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: scientific
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Ternary contours
     page_type: u-guide
     permalink: python/ternary-contour/

--- a/python/ternary-plots.md
+++ b/python/ternary-plots.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/39
     language: python
-    layout: user-guide
+    layout: base
     name: Ternary Plots
     order: 9
     page_type: example_index

--- a/python/ternary-scatter-contour.md
+++ b/python/ternary-scatter-contour.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/41
     language: python
-    layout: user-guide
+    layout: base
     name: Ternary Overlay
     order: 11
     page_type: u-guide

--- a/python/text-and-annotations.md
+++ b/python/text-and-annotations.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/204
     language: python
-    layout: user-guide
+    layout: base
     name: Text and Annotations
     order: 30
     permalink: python/text-and-annotations/

--- a/python/tick-formatting.md
+++ b/python/tick-formatting.md
@@ -176,6 +176,26 @@ fig.update_layout(
 fig.show()
 ```
 
+#### Placing ticks and gridlines between categories
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Bar(
+    x = ["apples", "oranges", "pears"],
+    y = [1, 2, 3]
+))
+
+fig.update_xaxes(
+    showgrid=True,
+    ticks="outside",
+    tickson="boundaries",
+    ticklen=20
+)
+
+fig.show()
+```
+
 #### Reference
 See https://plot.ly/python/reference/#layout-xaxis for more information and chart attribute options!
 

--- a/python/tick-formatting.md
+++ b/python/tick-formatting.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/1
     language: python
-    layout: user-guide
+    layout: base
     name: Formatting Ticks
     order: 10
     permalink: python/tick-formatting/

--- a/python/time-series.md
+++ b/python/time-series.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/213
     language: python
-    layout: user-guide
+    layout: base
     name: Time Series
     order: 0
     page_type: example_index

--- a/python/tree-plots.md
+++ b/python/tree-plots.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/28
     language: python
-    layout: user-guide
+    layout: base
     name: Tree-plots
     order: 10.5
     permalink: python/tree-plots/

--- a/python/treemaps.md
+++ b/python/treemaps.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/29
     language: python
-    layout: user-guide
+    layout: base
     name: Treemaps
     order: 11
     page_type: u-guide

--- a/python/v4-migration.md
+++ b/python/v4-migration.md
@@ -26,7 +26,7 @@ jupyter:
     display_as: file_settings
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Version 4 Migration Guide
     order: 1
     page_type: example_index

--- a/python/violin.md
+++ b/python/violin.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/201
     language: python
-    layout: user-guide
+    layout: base
     name: Violin Plots
     order: 12
     page_type: u-guide

--- a/python/visualizing-mri-volume-slices.md
+++ b/python/visualizing-mri-volume-slices.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/190
     language: python
-    layout: user-guide
+    layout: base
     name: Visualizing MRI Volume Slices
     order: 4
     page_type: example_index

--- a/python/waterfall-charts.md
+++ b/python/waterfall-charts.md
@@ -27,7 +27,7 @@ jupyter:
     has_thumbnail: true
     ipynb: /~notebook_demo/276
     language: python
-    layout: user-guide
+    layout: base
     name: Waterfall Charts
     order: 3
     page_type: example_index

--- a/python/webgl-vs-svg.md
+++ b/python/webgl-vs-svg.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/44
     language: python
-    layout: user-guide
+    layout: base
     name: WebGL vs SVG
     order: 0.5
     permalink: python/webgl-vs-svg/

--- a/python/wind-rose-charts.md
+++ b/python/wind-rose-charts.md
@@ -28,7 +28,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/38
     language: python
-    layout: user-guide
+    layout: base
     name: Wind Rose and Polar Bar Charts
     order: 8
     page_type: example_index

--- a/unconverted/python/1d-correlation.md
+++ b/unconverted/python/1d-correlation.md
@@ -17,7 +17,7 @@ jupyter:
     display_as: signal-analysis
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: 1D Correlation
     order: 5
     page_type: example_index

--- a/unconverted/python/2d-projection-of-3d-surface.md
+++ b/unconverted/python/2d-projection-of-3d-surface.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/79
     language: python
-    layout: user-guide
+    layout: base
     name: Projection of 3D Surface
     order: 19
     page_type: u-guide

--- a/unconverted/python/3d-filled-line-plots.md
+++ b/unconverted/python/3d-filled-line-plots.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/65
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Filled Line Plots
     order: 5
     permalink: python/3d-filled-line-plots/

--- a/unconverted/python/3d-network-graph.md
+++ b/unconverted/python/3d-network-graph.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/226
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Network Graphs
     order: 13
     page_type: example_index

--- a/unconverted/python/3d-parametric-plots.md
+++ b/unconverted/python/3d-parametric-plots.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/69
     language: python
-    layout: user-guide
+    layout: base
     name: Parametric Plots
     order: 9
     permalink: python/3d-parametric-plots/

--- a/unconverted/python/3d-point-clustering.md
+++ b/unconverted/python/3d-point-clustering.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/74
     language: python
-    layout: user-guide
+    layout: base
     name: 3d Clustering
     order: 14
     permalink: python/3d-point-clustering/

--- a/unconverted/python/3d-wireframe-plots.md
+++ b/unconverted/python/3d-wireframe-plots.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/68
     language: python
-    layout: user-guide
+    layout: base
     name: 3D Wireframe Plots
     order: 8
     permalink: python/3d-wireframe-plots/

--- a/unconverted/python/LaTeX.md
+++ b/unconverted/python/LaTeX.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/268
     language: python
-    layout: user-guide
+    layout: base
     name: LaTeX
     order: 3
     page_type: u-guide

--- a/unconverted/python/amazon-redshift.md
+++ b/unconverted/python/amazon-redshift.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/1
     language: python
-    layout: user-guide
+    layout: base
     name: Plot Data From Amazon Redshift
     order: 3
     page_type: example_index

--- a/unconverted/python/anova.md
+++ b/unconverted/python/anova.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/108
     language: python
-    layout: user-guide
+    layout: base
     name: Anova
     order: 8
     page_type: example_index

--- a/unconverted/python/apache-spark.md
+++ b/unconverted/python/apache-spark.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: databases
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Plot Data from Apache Spark
     order: 2
     page_type: example_index

--- a/unconverted/python/average_multiple_curves.md
+++ b/unconverted/python/average_multiple_curves.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/107
     language: python
-    layout: user-guide
+    layout: base
     name: Average Multiple Curves
     order: 9
     page_type: example_index

--- a/unconverted/python/baseline-detection.md
+++ b/unconverted/python/baseline-detection.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/117
     language: python
-    layout: user-guide
+    layout: base
     name: Baseline Detection
     order: 1
     page_type: example_index

--- a/unconverted/python/baseline-subtraction.md
+++ b/unconverted/python/baseline-subtraction.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/118
     language: python
-    layout: user-guide
+    layout: base
     name: Baseline Subtraction
     order: 2
     page_type: example_index

--- a/unconverted/python/basic-statistics.md
+++ b/unconverted/python/basic-statistics.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/109
     language: python
-    layout: user-guide
+    layout: base
     name: Basic Statistics
     order: 1
     page_type: example_index

--- a/unconverted/python/big-data-analytics-with-pandas-and-sqlite.md
+++ b/unconverted/python/big-data-analytics-with-pandas-and-sqlite.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/1
     language: python
-    layout: user-guide
+    layout: base
     name: Big Data Analytics with Pandas and SQLite
     order: 4
     page_type: example_index

--- a/unconverted/python/cars-exploration.md
+++ b/unconverted/python/cars-exploration.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/242
     language: python
-    layout: user-guide
+    layout: base
     name: Car Exploration with Hover Events
     order: 26
     permalink: python/cars-exploration/

--- a/unconverted/python/change-callbacks-datashader.md
+++ b/unconverted/python/change-callbacks-datashader.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/239
     language: python
-    layout: user-guide
+    layout: base
     name: DataShader Case Study
     order: 24
     permalink: python/change-callbacks-datashader/

--- a/unconverted/python/chord-diagram.md
+++ b/unconverted/python/chord-diagram.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/225
     language: python
-    layout: user-guide
+    layout: base
     name: Python Chord Diagram
     order: 24
     page_type: u-guide

--- a/unconverted/python/cmocean-colorscales.md
+++ b/unconverted/python/cmocean-colorscales.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/52
     language: python
-    layout: user-guide
+    layout: base
     name: Cmocean Colorscales
     order: 22
     page_type: example_index

--- a/unconverted/python/continuous-error-bars.md
+++ b/unconverted/python/continuous-error-bars.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/19
     language: python
-    layout: user-guide
+    layout: base
     name: Continuous Error Bars
     order: 2
     page_type: u-guide

--- a/unconverted/python/convolution.md
+++ b/unconverted/python/convolution.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: signal-analysis
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Convolution
     order: 4
     page_type: example_index

--- a/unconverted/python/create-online-dashboard-legacy.md
+++ b/unconverted/python/create-online-dashboard-legacy.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/148
     language: python
-    layout: user-guide
+    layout: base
     name: Dashboard API
     order: 0
     page_type: u-guide

--- a/unconverted/python/density-plots.md
+++ b/unconverted/python/density-plots.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/25
     language: python
-    layout: user-guide
+    layout: base
     name: 2d Density Plots
     order: 7
     page_type: u-guide

--- a/unconverted/python/discrete-frequency.md
+++ b/unconverted/python/discrete-frequency.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/110
     language: python
-    layout: user-guide
+    layout: base
     name: Discrete Frequency
     order: 3
     page_type: example_index

--- a/unconverted/python/exponential-fits.md
+++ b/unconverted/python/exponential-fits.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/135
     language: python
-    layout: user-guide
+    layout: base
     name: Exponential Fit
     order: 11
     page_type: example_index

--- a/unconverted/python/fft-filters.md
+++ b/unconverted/python/fft-filters.md
@@ -17,7 +17,7 @@ jupyter:
     display_as: signal-analysis
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: FFT Filters
     order: 2
     page_type: example_index

--- a/unconverted/python/filled-area-animation.md
+++ b/unconverted/python/filled-area-animation.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/128
     language: python
-    layout: user-guide
+    layout: base
     name: Filled-Area Animation
     order: 3
     page_type: example_index

--- a/unconverted/python/filled-chord-diagram.md
+++ b/unconverted/python/filled-chord-diagram.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/191
     language: python
-    layout: user-guide
+    layout: base
     name: Filled Chord Diagram
     order: 25
     page_type: u-guide

--- a/unconverted/python/frequency-counts.md
+++ b/unconverted/python/frequency-counts.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/111
     language: python
-    layout: user-guide
+    layout: base
     name: Frequency Counts
     order: 2
     page_type: example_index

--- a/unconverted/python/gapminder-example.md
+++ b/unconverted/python/gapminder-example.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/129
     language: python
-    layout: user-guide
+    layout: base
     name: Adding Sliders to Animations
     order: 2
     page_type: example_index

--- a/unconverted/python/google_big_query.md
+++ b/unconverted/python/google_big_query.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: databases
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Google Big-Query
     order: 7
     page_type: example_index

--- a/unconverted/python/graph-data-from-mysql-database-in-python.md
+++ b/unconverted/python/graph-data-from-mysql-database-in-python.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: databases
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Plot Data from MySQL
     order: 1
     page_type: example_index

--- a/unconverted/python/heatmap-animation.md
+++ b/unconverted/python/heatmap-animation.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/131
     language: python
-    layout: user-guide
+    layout: base
     name: Heatmap Animation
     order: 4
     page_type: example_index

--- a/unconverted/python/heatmap-webgl.md
+++ b/unconverted/python/heatmap-webgl.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/34
     language: python
-    layout: user-guide
+    layout: base
     name: WebGL Heatmaps
     order: 4
     page_type: u-guide

--- a/unconverted/python/html-reports.md
+++ b/unconverted/python/html-reports.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: report_generation
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     name: Python HTML Reports
     order: 1
     page_type: example_index

--- a/unconverted/python/igraph-networkx-comparison.md
+++ b/unconverted/python/igraph-networkx-comparison.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/222
     language: python
-    layout: user-guide
+    layout: base
     name: Network Graphs Comparison
     order: 14
     page_type: u-guide

--- a/unconverted/python/insets.md
+++ b/unconverted/python/insets.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: multiple_axes
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Inset Plots
     order: 3
     page_type: example_index

--- a/unconverted/python/interact-decorator.md
+++ b/unconverted/python/interact-decorator.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/254
     language: python
-    layout: user-guide
+    layout: base
     name: Use Interact decorator with FigureWidget
     order: 4
     permalink: python/interact-decorator/

--- a/unconverted/python/interpolation-and-extrapolation-in-1d.md
+++ b/unconverted/python/interpolation-and-extrapolation-in-1d.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/106
     language: python
-    layout: user-guide
+    layout: base
     name: Interpolation and Extrapolation in 1D
     order: 3
     page_type: example_index

--- a/unconverted/python/interpolation-and-extrapolation-in-2d.md
+++ b/unconverted/python/interpolation-and-extrapolation-in-2d.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/105
     language: python
-    layout: user-guide
+    layout: base
     name: Interpolation and Extrapolation in 2D
     order: 4
     page_type: example_index

--- a/unconverted/python/legacy-polar-chart.md
+++ b/unconverted/python/legacy-polar-chart.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/37
     language: python
-    layout: user-guide
+    layout: base
     name: Polar Charts [Legacy]
     order: 1
     page_type: u-guide

--- a/unconverted/python/linear-algebra.md
+++ b/unconverted/python/linear-algebra.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/104
     language: python
-    layout: user-guide
+    layout: base
     name: Linear Algebra
     order: 10
     page_type: example_index

--- a/unconverted/python/linear-fits.md
+++ b/unconverted/python/linear-fits.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/139
     language: python
-    layout: user-guide
+    layout: base
     name: Linear Fit
     order: 10
     page_type: example_index

--- a/unconverted/python/linear-gauge-chart.md
+++ b/unconverted/python/linear-gauge-chart.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/12
     language: python
-    layout: user-guide
+    layout: base
     name: Linear-Gauge Chart
     order: 12
     page_type: u-guide

--- a/unconverted/python/logos.md
+++ b/unconverted/python/logos.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/92
     language: python
-    layout: user-guide
+    layout: base
     name: Logos
     order: 6
     page_type: example_index

--- a/unconverted/python/matplotlib-colorscales.md
+++ b/unconverted/python/matplotlib-colorscales.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/48
     language: python
-    layout: user-guide
+    layout: base
     name: Matplotlib Colorscales
     order: 8
     page_type: example_index

--- a/unconverted/python/normality-test.md
+++ b/unconverted/python/normality-test.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/266
     language: python
-    layout: user-guide
+    layout: base
     name: Normality Tests
     order: 2
     page_type: u-guide

--- a/unconverted/python/normalization.md
+++ b/unconverted/python/normalization.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/103
     language: python
-    layout: user-guide
+    layout: base
     name: Normalization
     order: 2
     page_type: example_index

--- a/unconverted/python/numerical-differentiation.md
+++ b/unconverted/python/numerical-differentiation.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/102
     language: python
-    layout: user-guide
+    layout: base
     name: Numerical Differentiation
     order: 6
     page_type: example_index

--- a/unconverted/python/numerical-integration.md
+++ b/unconverted/python/numerical-integration.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/101
     language: python
-    layout: user-guide
+    layout: base
     name: Numerical Integration
     order: 7
     page_type: example_index

--- a/unconverted/python/outlier-test.md
+++ b/unconverted/python/outlier-test.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/113
     language: python
-    layout: user-guide
+    layout: base
     name: Outlier Test
     order: 6
     page_type: example_index

--- a/unconverted/python/pdf-reports.md
+++ b/unconverted/python/pdf-reports.md
@@ -16,7 +16,7 @@ jupyter:
     display_as: report_generation
     has_thumbnail: true
     language: python
-    layout: user-guide
+    layout: base
     name: Python PDF Reports
     order: 1
     page_type: example_index

--- a/unconverted/python/peak-fitting.md
+++ b/unconverted/python/peak-fitting.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/119
     language: python
-    layout: user-guide
+    layout: base
     name: Peak Fitting
     order: 5
     page_type: example_index

--- a/unconverted/python/peak-integration.md
+++ b/unconverted/python/peak-integration.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/121
     language: python
-    layout: user-guide
+    layout: base
     name: Peak Integration
     order: 4
     page_type: example_index

--- a/unconverted/python/polygon-area.md
+++ b/unconverted/python/polygon-area.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/100
     language: python
-    layout: user-guide
+    layout: base
     name: Polygon Area
     order: 8
     page_type: example_index

--- a/unconverted/python/polynomial-fits.md
+++ b/unconverted/python/polynomial-fits.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/138
     language: python
-    layout: user-guide
+    layout: base
     name: Polynomial Fit
     order: 12
     page_type: example_index

--- a/unconverted/python/population-pyramid-charts.md
+++ b/unconverted/python/population-pyramid-charts.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/221
     language: python
-    layout: user-guide
+    layout: base
     name: Population Pyramid Charts
     order: 5.01
     page_type: u-guide

--- a/unconverted/python/ribbon-plots.md
+++ b/unconverted/python/ribbon-plots.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/64
     language: python
-    layout: user-guide
+    layout: base
     name: Ribbon Plots
     order: 4
     permalink: python/ribbon-plots/

--- a/unconverted/python/salesforce.md
+++ b/unconverted/python/salesforce.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/1
     language: python
-    layout: user-guide
+    layout: base
     name: Plot Data from Salesforce
     order: 4
     page_type: example_index

--- a/unconverted/python/simple-mathematics-operations.md
+++ b/unconverted/python/simple-mathematics-operations.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/99
     language: python
-    layout: user-guide
+    layout: base
     name: Simple Mathematics Operations
     order: 1
     page_type: example_index

--- a/unconverted/python/statistics-charts.md
+++ b/unconverted/python/statistics-charts.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/116
     language: python
-    layout: user-guide
+    layout: base
     name: Statistics Charts
     order: 5
     page_type: example_index

--- a/unconverted/python/streaming-tutorial.md
+++ b/unconverted/python/streaming-tutorial.md
@@ -16,7 +16,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/80
     language: python
-    layout: user-guide
+    layout: base
     name: Plotly Streaming
     page_type: u-guide
     permalink: python/streaming-tutorial/

--- a/unconverted/python/surface-triangulation.md
+++ b/unconverted/python/surface-triangulation.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/71
     language: python
-    layout: user-guide
+    layout: base
     name: Surface Triangulation
     order: 11
     page_type: u-guide

--- a/unconverted/python/t-test.md
+++ b/unconverted/python/t-test.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/115
     language: python
-    layout: user-guide
+    layout: base
     name: T-Test
     order: 7
     page_type: example_index

--- a/unconverted/python/tesla-supercharging-stations.md
+++ b/unconverted/python/tesla-supercharging-stations.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/124
     language: python
-    layout: user-guide
+    layout: base
     name: Tesla Supercharging Stations
     order: 10
     page_type: u-guide

--- a/unconverted/python/trisurf.md
+++ b/unconverted/python/trisurf.md
@@ -18,7 +18,7 @@ jupyter:
     has_thumbnail: true
     ipynb: ~notebook_demo/70
     language: python
-    layout: user-guide
+    layout: base
     name: Trisurf Plots
     order: 10
     page_type: u-guide

--- a/unconverted/python/userguide.md
+++ b/unconverted/python/userguide.md
@@ -15,7 +15,7 @@ jupyter:
     description: Getting Started with Plotly for Python
     has_thumbnail: false
     language: python
-    layout: user-guide
+    layout: base
     page_type: u-guide
     permalink: python/userguide/
     thumbnail: null

--- a/unconverted/python/webgl-text-and-annotations.md
+++ b/unconverted/python/webgl-text-and-annotations.md
@@ -17,7 +17,7 @@ jupyter:
     has_thumbnail: false
     ipynb: ~notebook_demo/219
     language: python
-    layout: user-guide
+    layout: base
     name: WebGL Text and Annotations
     order: 2
     page_type: example_index


### PR DESCRIPTION
The sunburst basic example doesn't have explanation, so I wanna add it to the documentation for readers to understand faster.

Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
