### PR TITLE
interpret backticks as code

### DIFF
--- a/apidoc/conf.py
+++ b/apidoc/conf.py
@@ -98,7 +98,7 @@ html_theme_options = {
         'analytics_id':'UA-39373211-1',
         'logo':'logo.png',
         'page_width': '70%',
-        'sidebar_width':'15%'
+        'sidebar_width':'20%'
         }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/apidoc/conf.py
+++ b/apidoc/conf.py
@@ -80,6 +80,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+default_role = "literal"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This is not the default in sphinx, since in rst code is with double backticks (backquotes).