### PR TITLE
Add new example with values and centered text

### DIFF
--- a/python/treemaps.md
+++ b/python/treemaps.md
@@ -50,6 +50,27 @@ fig = go.Figure(go.Treemap(
 
 fig.show()
 ```
+### Basic Treemap with values and adjusted text styles
+
+This example demonstrate how to add values to the treemap and adjusted the text font size and textinfo for displaying the results.
+The text will be larger and centered in the treemap. The next section explains the attributes you can use for Treemap.
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure(go.Treemap(
+    values = [0, 5, 20, 4, 2, 1], # treemap value for CS class
+    labels = ["CS Class", "A student","B student", "C student", "D student", "F student"],
+    parents = ["", "CS Class", "CS Class", "CS Class", "CS Class", "CS Class"],
+    textposition='middle center', # center the text
+    textinfo = "label+percent parent", # show label and its percentage among the whole treemap
+    textfont=dict(
+        size=15 # adjust small text to larger text
+    )
+))
+
+fig.show()
+```
 
 ### Set Different Attributes in Treemap
 


### PR DESCRIPTION
Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
