### PR TITLE
Disable autosize on double click

### DIFF
--- a/python/images.md
+++ b/python/images.md
@@ -302,6 +302,8 @@ fig.update_layout(
     margin={"l": 0, "r": 0, "t": 0, "b": 0},
 )
 
+# Disable the autosize on double click because it adds unwanted margins around the image
+# More detail: https://plot.ly/python/configuration-options/
 fig.show(config={'doubleClick': 'reset'})
 ```
 

--- a/python/images.md
+++ b/python/images.md
@@ -302,7 +302,7 @@ fig.update_layout(
     margin={"l": 0, "r": 0, "t": 0, "b": 0},
 )
 
-fig.show()
+fig.show(config={'doubleClick': 'reset'})
 ```
 
 #### Reference


### PR DESCRIPTION
Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14

---
https://plot.ly/python/images/#zoom-on-static-images

This PR proposes to disable `autosize` on double click and use only `reset` because `autosize` adds margins around the image.

## Current (example on the doc)
![demo-reset](https://user-images.githubusercontent.com/17039389/67157324-99daa380-f365-11e9-939f-cdede3563ee5.gif)

## Proposed (tested on Jupyter)
![proposed](https://user-images.githubusercontent.com/17039389/67157351-ed4cf180-f365-11e9-9515-5ee03edd058a.gif)
