### PR TITLE
Update scipy to the current latest version to suppress FutureWarning

### DIFF
--- a/python/images.md
+++ b/python/images.md
@@ -150,6 +150,8 @@ import plotly.graph_objects as go
 
 import numpy as np
 np.random.seed(1)
+import scipy
+print(scipy.__version__)
 from scipy.signal import savgol_filter
 
 # Simulate spectroscopy data

--- a/python/images.md
+++ b/python/images.md
@@ -150,8 +150,6 @@ import plotly.graph_objects as go
 
 import numpy as np
 np.random.seed(1)
-import scipy
-print(scipy.__version__)
 from scipy.signal import savgol_filter
 
 # Simulate spectroscopy data

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jupytext==1.1.1
 jupyter
 notebook
 pandas==0.23.0
-statsmodels==0.9.0
+statsmodels==0.10.1
 scipy==1.3.1
 patsy==0.5.1
 numpy==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jupyter
 notebook
 pandas==0.23.0
 statsmodels==0.9.0
-scipy==1.1.0
+scipy==1.3.1
 patsy==0.5.1
 numpy==1.16.0
 plotly-geo


### PR DESCRIPTION
This PR updates `scipy` to the current latest version `1.3.1` ([release history](https://pypi.org/project/scipy/#history)) to resolve #148.
