### PR TITLE
removing titles since they are now autogenerated from name

### DIFF
--- a/python/2D-Histogram.md
+++ b/python/2D-Histogram.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/2D-Histogram/
     thumbnail: thumbnail/histogram2d.jpg
-    title: Python 2D Histograms | plotly
+    
 ---
 
 ### 2D Histogram of a Bivariate Normal Distribution ###

--- a/python/2d-histogram-contour.md
+++ b/python/2d-histogram-contour.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/2d-histogram-contour/
     thumbnail: thumbnail/hist2dcontour.png
-    title: 2D Histogram Contour | Plotly
+    
 ---
 
 #### Basic 2D Histogram Contour

--- a/python/3d-axes.md
+++ b/python/3d-axes.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/3d-axes/
     thumbnail: thumbnail/3d-axes.png
-    title: Format 3d Axes | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/3d-bubble-charts.md
+++ b/python/3d-bubble-charts.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/3d-bubble-charts/
     thumbnail: thumbnail/3dbubble.jpg
-    title: Python 3D Bubble Charts | plotly
+    
 ---
 
 ### 3d Bubble chart with Plotly Express

--- a/python/3d-camera-controls.md
+++ b/python/3d-camera-controls.md
@@ -32,7 +32,7 @@ jupyter:
     order: 0.108
     permalink: python/3d-camera-controls/
     thumbnail: thumbnail/3d-camera-controls.jpg
-    title: Python 3D Camera Controls | plotly
+    
 ---
 
 ### How camera controls work

--- a/python/3d-isosurface-plots.md
+++ b/python/3d-isosurface-plots.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/3d-isosurface-plots/
     redirect_from: python/isosurfaces-with-marching-cubes/
     thumbnail: thumbnail/isosurface.jpg
-    title: Python 3D Isosurface Plots | plotly
+    
 ---
 
 With ``go.Isosurface``, you can plot [isosurface contours](https://en.wikipedia.org/wiki/Isosurface) of a scalar field ``value``, which is defined on ``x``, ``y`` and ``z`` coordinates.

--- a/python/3d-line-plots.md
+++ b/python/3d-line-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/3d-line-plots/
     thumbnail: thumbnail/3d-line.jpg
-    title: 3D Line Plots in Python | plotly
+    
 ---
 
 ### 3D Line plot with Plotly Express

--- a/python/3d-mesh.md
+++ b/python/3d-mesh.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/3d-mesh/
     thumbnail: thumbnail/3d-mesh.jpg
-    title: 3D Mesh Plots in Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/3d-scatter-plots.md
+++ b/python/3d-scatter-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/3d-scatter-plots/
     thumbnail: thumbnail/3d-scatter.jpg
-    title: 3D Python Scatter Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/3d-subplots.md
+++ b/python/3d-subplots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/3d-subplots/
     thumbnail: thumbnail/3d-subplots.jpg
-    title: 3D Subplots in Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/3d-surface-coloring.md
+++ b/python/3d-surface-coloring.md
@@ -32,7 +32,7 @@ jupyter:
     order: 7
     permalink: python/3d-surface-coloring/
     thumbnail: thumbnail/3d-surface-color.jpg
-    title: 3D Surface Coloring in Python | plotly
+    
 ---
 
 ```python

--- a/python/3d-surface-plots.md
+++ b/python/3d-surface-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/3d-surface-plots/
     thumbnail: thumbnail/3d-surface.jpg
-    title: 3D Surface Plots in Python | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/3d-volume.md
+++ b/python/3d-volume.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: u-guide
     permalink: python/3d-volume-plots/
     thumbnail: thumbnail/3d-volume-plots.jpg
-    title: Python 3D Volume Plots | plotly
+    
 ---
 
 A volume plot with `go.Volume` shows several partially transparent isosurfaces for volume rendering. The API of `go.Volume` is close to the one of `go.Isosurface`. However, whereas [isosurface plots](./3d-isosurface-plots/) show all surfaces with the same opacity, tweaking the `opacityscale` parameter of `go.Volume` results in a depth effect and better volume rendering.

--- a/python/aggregations.md
+++ b/python/aggregations.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/aggregations/
     thumbnail: thumbnail/aggregations.jpg
-    title: Aggregations | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/animations.md
+++ b/python/animations.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/animations/
     thumbnail: thumbnail/animations.gif
-    title: Intro to Animations in Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/annotated_heatmap.md
+++ b/python/annotated_heatmap.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/annotated_heatmap/
     thumbnail: thumbnail/ann_heat.jpg
-    title: Python Annotated Heatmaps | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/axes.md
+++ b/python/axes.md
@@ -34,7 +34,7 @@ jupyter:
     order: 12
     permalink: python/axes/
     thumbnail: thumbnail/axes.png
-    title: Axes | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/bar-charts.md
+++ b/python/bar-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/bar-charts/
     thumbnail: thumbnail/bar.jpg
-    title: Bar Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/box-plots.md
+++ b/python/box-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/box-plots/
     thumbnail: thumbnail/box.jpg
-    title: Box Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/bubble-charts.md
+++ b/python/bubble-charts.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/bubble-charts/
     redirect_from: python/bubble-charts-tutorial/
     thumbnail: thumbnail/bubble.jpg
-    title: Bubble Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/bubble-maps.md
+++ b/python/bubble-maps.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: example_index
     permalink: python/bubble-maps/
     thumbnail: thumbnail/bubble-map.jpg
-    title: Python Bubble Maps | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/bullet-charts.md
+++ b/python/bullet-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/bullet-charts/
     thumbnail: thumbnail/bullet.png
-    title: Python Bullet Chart | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/candlestick-charts.md
+++ b/python/candlestick-charts.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: example_index
     permalink: python/candlestick-charts/
     thumbnail: thumbnail/candlestick.jpg
-    title: Python Candlestick Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/carpet-contour.md
+++ b/python/carpet-contour.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/carpet-contour/
     thumbnail: thumbnail/contourcarpet.jpg
-    title: Carpet Contour Plots | Plotly
+    
 ---
 
 ### Basic Carpet Plot

--- a/python/carpet-plot.md
+++ b/python/carpet-plot.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/carpet-plot/
     thumbnail: thumbnail/carpet.jpg
-    title: Carpet Plots | Plotly
+    
 ---
 
 <!-- #region -->

--- a/python/carpet-scatter.md
+++ b/python/carpet-scatter.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/carpet-scatter/
     thumbnail: thumbnail/scattercarpet.jpg
-    title: Carpet Scatter Plots | Plotly
+    
 ---
 
 

--- a/python/choropleth-maps.md
+++ b/python/choropleth-maps.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/choropleth-maps/
     thumbnail: thumbnail/choropleth.jpg
-    title: Python Choropleth Maps | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/click-events.md
+++ b/python/click-events.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/click-events/
     thumbnail: thumbnail/figurewidget-click-events.gif
-    title: Click Events
+    
     v4upgrade: true
 ---
 

--- a/python/colorscales.md
+++ b/python/colorscales.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/colorscales/
     thumbnail: thumbnail/heatmap_colorscale.jpg
     redirect_from: python/logarithmic-color-scale/
-    title: Colorscales in Python | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/compare-webgl-svg.md
+++ b/python/compare-webgl-svg.md
@@ -31,7 +31,7 @@ jupyter:
     page_type: example_index
     permalink: python/compare-webgl-svg/
     thumbnail: /images/static-image
-    title: Comparing WebGL vs SVG | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/cone-plot.md
+++ b/python/cone-plot.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/cone-plot/
     redirect_from: python/3d-cone/
     thumbnail: thumbnail/3dcone.png
-    title: 3D Cone Plots | Plotly
+    
 ---
 
 A cone plot is the 3D equivalent of a 2D [quiver plot](./quiver-plots/), i.e., it represents a 3D vector field using cones to represent the direction and norm of the vectors. 3-D coordinates are given by `x`, `y` and `z`, and the coordinates of the vector field by `u`, `v` and `w`.

--- a/python/configuration-options.md
+++ b/python/configuration-options.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/configuration-options/
     thumbnail: thumbnail/modebar-icons.png
-    title: Configuration | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/contour-plots.md
+++ b/python/contour-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/contour-plots/
     thumbnail: thumbnail/contour.jpg
-    title: Contour Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/county-choropleth.md
+++ b/python/county-choropleth.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/county-choropleth/
     thumbnail: thumbnail/county-choropleth-usa-greybkgd.jpg
-    title: Python USA County Choropleth Maps | Plotly
+    
 ---
 
 #### Required Packages

--- a/python/creating-and-updating-figures.md
+++ b/python/creating-and-updating-figures.md
@@ -34,7 +34,7 @@ jupyter:
       - python/user-guide/
       - python/user-g/
     thumbnail: thumbnail/creating-and-updating-figures.png
-    title: Creating and Updating Figures | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/custom-buttons.md
+++ b/python/custom-buttons.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: example_index
     permalink: python/custom-buttons/
     thumbnail: thumbnail/custom-buttons.jpg
-    title: Custom Buttons | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/dendrogram.md
+++ b/python/dendrogram.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/dendrogram/
     thumbnail: thumbnail/dendrogram.jpg
-    title: Dendrograms | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/distplot.md
+++ b/python/distplot.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/distplot/
     thumbnail: thumbnail/distplot.jpg
-    title: Python Distplots | plotly
+    
 ---
 
 ## Combined statistical representations with px.histogram

--- a/python/dot-plots.md
+++ b/python/dot-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/dot-plots/
     thumbnail: thumbnail/dot-plot.jpg
-    title: Python Dot Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/dropdowns.md
+++ b/python/dropdowns.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/dropdowns/
     thumbnail: thumbnail/dropdown.jpg
-    title: Dropdown Menus | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/error-bars.md
+++ b/python/error-bars.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/error-bars/
     thumbnail: thumbnail/error-bar.jpg
-    title: Error Bars | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/facet-plots.md
+++ b/python/facet-plots.md
@@ -33,7 +33,7 @@ jupyter:
     permalink: python/facet-plots/
     redirect_from: python/trellis-plots/
     thumbnail: thumbnail/facet-trellis-thumbnail.jpg
-    title: Python Facet and Trellis Plots | plotly
+    
 ---
 
 

--- a/python/figure-factory-subplots.md
+++ b/python/figure-factory-subplots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/figure-factory-subplots/
     thumbnail: thumbnail/ff-subplots.jpg
-    title: Figure Factory Subplots in Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/figure-labels.md
+++ b/python/figure-labels.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/figure-labels/
     redirect_from: python/font/
     thumbnail: thumbnail/figure-labels.png
-    title: Setting the Font, Title, Legend Entries, and Axis Titles in Python
+    
     v4upgrade: true
 ---
 

--- a/python/figurewidget-app.md
+++ b/python/figurewidget-app.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/figurewidget-app/
     thumbnail: thumbnail/multi-widget.jpg
-    title: Interactive Data Analysis with FigureWidget ipywidgets
+    
     v4upgrade: true
 ---
 

--- a/python/figurewidget.md
+++ b/python/figurewidget.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/figurewidget/
     thumbnail: thumbnail/figurewidget-overview.gif
-    title: Plotly FigureWidget Overview
+    
     v4upgrade: true
 ---
 

--- a/python/filled-area-on-mapbox.md
+++ b/python/filled-area-on-mapbox.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/filled-area-on-mapbox/
     thumbnail: thumbnail/area.jpg
-    title: Python Mapbox Choropleth Maps | plotly
+    
 ---
 
 <!-- #region -->

--- a/python/filled-area-plots.md
+++ b/python/filled-area-plots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/filled-area-plots/
     thumbnail: thumbnail/area.jpg
-    title: Filled Area Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/filter.md
+++ b/python/filter.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/filter/
     thumbnail: thumbnail/filter.jpg
-    title: Filter | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/funnel-charts.md
+++ b/python/funnel-charts.md
@@ -16,7 +16,7 @@ jupyter:
     description: How to make funnel-chart plots in Python with Plotly.
     name: Funnel Chart
     thumbnail: thumbnail/funnel.jpg
-    title: Python Funnel Chart | Plotly
+    
     has_thumbnail: true
     language: python
     display_as: financial

--- a/python/gantt.md
+++ b/python/gantt.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/gantt/
     thumbnail: thumbnail/gantt.jpg
-    title: Python Gantt Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/gauge-charts.md
+++ b/python/gauge-charts.md
@@ -36,7 +36,7 @@ jupyter:
     - python/gauge-chart/
     - python/gauge-meter/
     thumbnail: thumbnail/gauge.jpg
-    title: Python Gauge Chart | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/getting-started.md
+++ b/python/getting-started.md
@@ -31,7 +31,7 @@ jupyter:
     page_type: u-guide
     permalink: python/getting-started/
     redirect_from: python/getting_started/
-    title: Getting Started with Plotly for Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/graphing-multiple-chart-types.md
+++ b/python/graphing-multiple-chart-types.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: u-guide
     permalink: python/graphing-multiple-chart-types/
     thumbnail: thumbnail/multiple-chart-type.jpg
-    title: Python Mulitple Chart Types | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/group-by.md
+++ b/python/group-by.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/group-by/
     thumbnail: thumbnail/groupby.jpg
-    title: Group By | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/heatmaps.md
+++ b/python/heatmaps.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/heatmaps/
     redirect_from: python/heatmap/
     thumbnail: thumbnail/heatmap.jpg
-    title: Python Heatmaps | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/histograms.md
+++ b/python/histograms.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/histograms/
     redirect_from: /python/histogram-tutorial/
     thumbnail: thumbnail/histogram.jpg
-    title: Python Histograms | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/horizontal-bar-charts.md
+++ b/python/horizontal-bar-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/horizontal-bar-charts/
     thumbnail: thumbnail/horizontal-bar.jpg
-    title: Horizontal Bar Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/horizontal-legend.md
+++ b/python/horizontal-legend.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/horizontal-legend/
     thumbnail: thumbnail/your-tutorial-chart.jpg
-    title: Horizontal legend | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/hover-text-and-formatting.md
+++ b/python/hover-text-and-formatting.md
@@ -32,7 +32,7 @@ jupyter:
     order: 30.5
     permalink: python/hover-text-and-formatting/
     thumbnail: thumbnail/hover-text.png
-    title: Hover Text and Formatting | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/images.md
+++ b/python/images.md
@@ -32,7 +32,7 @@ jupyter:
     order: 31
     permalink: python/images/
     thumbnail: thumbnail/images.png
-    title: Layout with images | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/indicator.md
+++ b/python/indicator.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/indicator/
     thumbnail: thumbnail/indicator.jpg
-    title: Python Gauge Chart | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/ipython-vs-python.md
+++ b/python/ipython-vs-python.md
@@ -32,7 +32,7 @@ jupyter:
     order: 41
     permalink: python/ipython-vs-python/
     thumbnail: thumbnail/venn.jpg
-    title: IPython vs Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/jupyter-lab-tools.md
+++ b/python/jupyter-lab-tools.md
@@ -31,7 +31,7 @@ jupyter:
     order: 2
     permalink: python/jupyter-lab-tools/
     thumbnail: thumbnail/figurewidget-jupyterlab.png
-    title: Jupyter Lab with FigureWidget
+    
     v4upgrade: true
 ---
 

--- a/python/legend.md
+++ b/python/legend.md
@@ -32,7 +32,7 @@ jupyter:
     order: 13
     permalink: python/legend/
     thumbnail: thumbnail/legends.gif
-    title: Legends | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/line-and-scatter.md
+++ b/python/line-and-scatter.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/line-and-scatter/
     redirect_from: python/line-and-scatter-plots-tutorial/
     thumbnail: thumbnail/line-and-scatter.jpg
-    title: Python Scatter Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/line-charts.md
+++ b/python/line-charts.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/line-charts/
     thumbnail: thumbnail/line-plot.jpg
-    title: Python Line Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/lines-on-mapbox.md
+++ b/python/lines-on-mapbox.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/lines-on-mapbox/
     thumbnail: thumbnail/line_mapbox.jpg
-    title: Lines on Mapbox | plotly
+    
 ---
 
 ### Mapbox Access Token

--- a/python/lines-on-maps.md
+++ b/python/lines-on-maps.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/lines-on-maps/
     thumbnail: thumbnail/flight-paths.jpg
-    title: Lines on maps | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/log-plot.md
+++ b/python/log-plot.md
@@ -32,7 +32,7 @@ jupyter:
     order: 1
     permalink: python/log-plot/
     thumbnail: thumbnail/log.jpg
-    title: Python Log Plots | plotly
+    
 ---
 
 ### Logarithmic Axes ###

--- a/python/map-subplots-and-small-multiples.md
+++ b/python/map-subplots-and-small-multiples.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/map-subplots-and-small-multiples/
     thumbnail: thumbnail/map-subplots.jpg
-    title: Python Map Subplots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/mapbox-county-choropleth.md
+++ b/python/mapbox-county-choropleth.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/mapbox-county-choropleth/
     thumbnail: thumbnail/mapbox-choropleth.png
-    title: Python Mapbox Choropleth Maps | plotly
+    
 ---
 
 

--- a/python/mapbox-density-heatmaps.md
+++ b/python/mapbox-density-heatmaps.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/mapbox-density-heatmaps/
     thumbnail: thumbnail/mapbox-density.png
-    title: Python Density Heatmap | plotly
+    
 ---
 
 

--- a/python/mapbox-layers.md
+++ b/python/mapbox-layers.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/mapbox-layers/
     thumbnail: thumbnail/mapbox-layers.png
-    title: Mapbox Map Layers in Python | Plotly
+    
 ---
 
 <!-- #region -->

--- a/python/marker-style.md
+++ b/python/marker-style.md
@@ -32,7 +32,7 @@ jupyter:
     order: 21
     permalink: python/marker-style/
     thumbnail: thumbnail/marker-style.gif
-    title: Styling Markers | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/mixed-subplots.md
+++ b/python/mixed-subplots.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/mixed-subplots/
     thumbnail: thumbnail/mixed_subplot.JPG
-    title: Mixed Subplots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/multiple-axes.md
+++ b/python/multiple-axes.md
@@ -32,7 +32,7 @@ jupyter:
     order: 14
     permalink: python/multiple-axes/
     thumbnail: thumbnail/multiple-axes.jpg
-    title: Python Multiple Axes | Examples | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/multiple-transforms.md
+++ b/python/multiple-transforms.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/multiple-transforms/
     thumbnail: thumbnail/multiple-transforms.jpg
-    title: Multiple Transforms | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/orca-management.md
+++ b/python/orca-management.md
@@ -33,7 +33,7 @@ jupyter:
     order: 1.5
     permalink: python/orca-management/
     thumbnail: thumbnail/orca-management.png
-    title: Orca Management | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/parallel-categories-diagram.md
+++ b/python/parallel-categories-diagram.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/parallel-categories-diagram/
     thumbnail: thumbnail/parcats.jpg
-    title: Python Parallel Categories | Plotly
+    
 ---
 
 #### Parallel Categories Diagram

--- a/python/parallel-coordinates-plot.md
+++ b/python/parallel-coordinates-plot.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/parallel-coordinates-plot/
     thumbnail: thumbnail/parcoords.jpg
-    title: Parallel Coordinates Plot | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/peak-finding.md
+++ b/python/peak-finding.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/peak-finding/
     thumbnail: /images/static-image
-    title: Peak Finding in Python | plotly
+    
 ---
 
 #### Imports

--- a/python/pie-charts.md
+++ b/python/pie-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/pie-charts/
     thumbnail: thumbnail/pie-chart.jpg
-    title: Pie Charts in Python | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/plot-data-from-csv.md
+++ b/python/plot-data-from-csv.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/plot-data-from-csv/
     thumbnail: thumbnail/csv.jpg
-    title: Plot Data from CSV | plotly
+    
 ---
 
 

--- a/python/plotly-express.md
+++ b/python/plotly-express.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/plotly-express/
     thumbnail: thumbnail/plotly-express.png
-    title: Plotly Express
+    
     v4upgrade: true
 ---
 

--- a/python/polar-chart.md
+++ b/python/polar-chart.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/polar-chart/
     thumbnail: thumbnail/polar.gif
-    title: Polar Charts | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/px-arguments.md
+++ b/python/px-arguments.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/px-arguments/
     thumbnail: thumbnail/plotly-express.png
-    title: Plotly Express Arguments
+    
     v4upgrade: true
 ---
 

--- a/python/quiver-plots.md
+++ b/python/quiver-plots.md
@@ -33,7 +33,7 @@ jupyter:
     order: 12
     permalink: python/quiver-plots/
     thumbnail: thumbnail/quiver-plot.jpg
-    title: Python Quiver Plots | plotly
+    
 ---
 
 #### Basic Quiver Plot

--- a/python/radar-chart.md
+++ b/python/radar-chart.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/radar-chart/
     thumbnail: thumbnail/radar.gif
-    title: Radar Charts | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/random-walk.md
+++ b/python/random-walk.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/random-walk/
     thumbnail: /images/static-image
-    title: Random Walk in Python. | plotly
+    
 ---
 
 A [random walk](https://en.wikipedia.org/wiki/Random_walk) can be thought of as a random process in which a token or a marker is randomly moved around some space, that is, a space with a metric used to compute distance. It is more commonly conceptualized in one dimension ($\mathbb{Z}$), two dimensions ($\mathbb{Z}^2$) or three dimensions ($\mathbb{Z}^3$) in Cartesian space, where $\mathbb{Z}$ represents the set of integers. In the visualizations below, we will be using [scatter plots](https://plot.ly/python/line-and-scatter/) as well as a colorscale to denote the time sequence of the walk.

--- a/python/range-slider.md
+++ b/python/range-slider.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/range-slider/
     thumbnail: thumbnail/sliders.jpg
-    title: Python Range Slider and Selectors | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/renderers.md
+++ b/python/renderers.md
@@ -33,7 +33,7 @@ jupyter:
     permalink: python/renderers/
     redirect_from: python/offline/
     thumbnail: thumbnail/displaying-figures.png
-    title: Displaying Figures | plotly
+    
 ---
 
 ### Displaying plotly figures

--- a/python/sankey-diagram.md
+++ b/python/sankey-diagram.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/sankey-diagram/
     thumbnail: thumbnail/sankey.jpg
-    title: Sankey Diagram | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/scatter-plots-on-maps.md
+++ b/python/scatter-plots-on-maps.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/scatter-plots-on-maps/
     thumbnail: thumbnail/scatter-plot-on-maps.jpg
-    title: Python Scatter Plots on Maps | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/scattermapbox.md
+++ b/python/scattermapbox.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: u-guide
     permalink: python/scattermapbox/
     thumbnail: thumbnail/scatter-mapbox.jpg
-    title: Python Scatter Plots with Mapbox | Plotly
+    
 ---
 
 #### Mapbox Access Token

--- a/python/setting-graph-size.md
+++ b/python/setting-graph-size.md
@@ -32,7 +32,7 @@ jupyter:
     order: 2
     permalink: python/setting-graph-size/
     thumbnail: thumbnail/sizing.png
-    title: Setting Graph Size
+    
     v4upgrade: true
 ---
 

--- a/python/shapes.md
+++ b/python/shapes.md
@@ -33,7 +33,7 @@ jupyter:
     order: 32
     permalink: python/shapes/
     thumbnail: thumbnail/shape.jpg
-    title: Shapes | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/sliders.md
+++ b/python/sliders.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/sliders/
     thumbnail: thumbnail/slider2017.gif
-    title: Python Slider Controls | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/smoothing.md
+++ b/python/smoothing.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: example_index
     permalink: python/smoothing/
     thumbnail: /images/static-image
-    title: Smoothing in Python | plotly
+    
 ---
 
 

--- a/python/splom.md
+++ b/python/splom.md
@@ -34,7 +34,7 @@ jupyter:
     permalink: python/splom/
     redirect_from: python/scatterplot-matrix/
     thumbnail: thumbnail/splom_image.jpg
-    title: Python Scatterplot Matrix | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/static-image-export.md
+++ b/python/static-image-export.md
@@ -35,7 +35,7 @@ jupyter:
     page_type: u-guide
     permalink: python/static-image-export/
     thumbnail: thumbnail/static-image-export.png
-    title: Static Image Export | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/streamline-plots.md
+++ b/python/streamline-plots.md
@@ -33,7 +33,7 @@ jupyter:
     order: 13
     permalink: python/streamline-plots/
     thumbnail: thumbnail/streamline.jpg
-    title: Python Streamline Plots | plotly
+    
 ---
 
 A Streamline plot is a representation based on a 2-D vector field interpreted as a velocity field, consisting of closed curves tangent to the velocity field. In the case of a stationary velocity field, streamlines coincide with trajectories (see also the [Wikipedia page on streamlines, streaklines and pathlines](https://en.wikipedia.org/wiki/Streamlines,_streaklines,_and_pathlines)).

--- a/python/streamtube-plot.md
+++ b/python/streamtube-plot.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/streamtube-plot/
     thumbnail: thumbnail/streamtube.jpg
-    title: 3D Streamtube Plots | Plotly
+    
 ---
 
 

--- a/python/subplots.md
+++ b/python/subplots.md
@@ -35,7 +35,7 @@ jupyter:
     permalink: python/subplots/
     redirect_from: ipython-notebooks/subplots/
     thumbnail: thumbnail/subplots.jpg
-    title: Python Subplots | Examples | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/sunburst-charts.md
+++ b/python/sunburst-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/sunburst-charts/
     thumbnail: thumbnail/sunburst.gif
-    title: Sunburst in Python | plotly
+    
 ---
 
 ### Basic Sunburst Plot ###

--- a/python/table-subplots.md
+++ b/python/table-subplots.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: example_index
     permalink: python/table-subplots/
     thumbnail: thumbnail/table_subplots.jpg
-    title: Table and Chart Subplots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/table.md
+++ b/python/table.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/table/
     thumbnail: thumbnail/table.gif
-    title: Tables | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/templates.md
+++ b/python/templates.md
@@ -32,7 +32,7 @@ jupyter:
     layout: base
     permalink: python/templates/
     thumbnail: thumbnail/theming-and-templates.png
-    title: Theming and templates | plotly
+    
 ---
 
 ### Theming and templates

--- a/python/ternary-contour.md
+++ b/python/ternary-contour.md
@@ -31,7 +31,7 @@ jupyter:
     page_type: u-guide
     permalink: python/ternary-contour/
     thumbnail: thumbnail/ternary-contour.jpg
-    title: Python Ternary contours | plotly
+    
 ---
 
 ## Ternary contour plots

--- a/python/text-and-annotations.md
+++ b/python/text-and-annotations.md
@@ -32,7 +32,7 @@ jupyter:
     order: 30
     permalink: python/text-and-annotations/
     thumbnail: thumbnail/text-and-annotations.png
-    title: Text and Annotations | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/tick-formatting.md
+++ b/python/tick-formatting.md
@@ -32,7 +32,7 @@ jupyter:
     order: 10
     permalink: python/tick-formatting/
     thumbnail: thumbnail/tick-formatting.gif
-    title: Formatting Ticks | Plotly
+    
 ---
 
 #### Tickmode - Linear

--- a/python/time-series.md
+++ b/python/time-series.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/time-series/
     thumbnail: thumbnail/time-series.jpg
-    title: Time Series Plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/tree-plots.md
+++ b/python/tree-plots.md
@@ -33,7 +33,7 @@ jupyter:
     order: 10.5
     permalink: python/tree-plots/
     thumbnail: thumbnail/treeplot.jpg
-    title: Python Tree-plots | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/treemaps.md
+++ b/python/treemaps.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/treemaps/
     thumbnail: thumbnail/treemap.png
-    title: Treemap in Python | plotly
+    
 ---
 
 ### Basic Treemap

--- a/python/v4-migration.md
+++ b/python/v4-migration.md
@@ -32,7 +32,7 @@ jupyter:
     page_type: example_index
     permalink: python/v4-migration/
     thumbnail: thumbnail/v4-migration.png
-    title: Version 4 migration guide | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/violin.md
+++ b/python/violin.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: u-guide
     permalink: python/violin/
     thumbnail: thumbnail/violin.jpg
-    title: Violin Plots | Plotly
+    
     v4upgrade: true
 ---
 

--- a/python/visualizing-mri-volume-slices.md
+++ b/python/visualizing-mri-volume-slices.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/visualizing-mri-volume-slices/
     thumbnail: thumbnail/brain-mri-animation_square.gif
-    title: Visualizing MRI Volume Slices | plotly
+    
 ---
 
 #### Visualization of MRI volume slices

--- a/python/waterfall-charts.md
+++ b/python/waterfall-charts.md
@@ -33,7 +33,7 @@ jupyter:
     page_type: example_index
     permalink: python/waterfall-charts/
     thumbnail: thumbnail/waterfall-charts.jpg
-    title: Python Waterfall Chart | Plotly
+    
 ---
 
 ### Simple Waterfall Chart

--- a/python/webgl-vs-svg.md
+++ b/python/webgl-vs-svg.md
@@ -33,7 +33,7 @@ jupyter:
     order: 0.5
     permalink: python/webgl-vs-svg/
     thumbnail: thumbnail/webgl.jpg
-    title: Python WebGL vs SVG | plotly
+    
     v4upgrade: true
 ---
 

--- a/python/wind-rose-charts.md
+++ b/python/wind-rose-charts.md
@@ -34,7 +34,7 @@ jupyter:
     page_type: example_index
     permalink: python/wind-rose-charts/
     thumbnail: thumbnail/wind-rose.jpg
-    title: Python Wind Rose Charts | plotly
+    
     v4upgrade: true
 ---
 

--- a/unconverted/python/1d-correlation.md
+++ b/unconverted/python/1d-correlation.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/1d-correlation/
     thumbnail: /images/static-image
-    title: 1D Correlation in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/2d-projection-of-3d-surface.md
+++ b/unconverted/python/2d-projection-of-3d-surface.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/2d-projection-of-3d-surface/
     thumbnail: thumbnail/projection-3d.jpg
-    title: 2D Projection of 3D surface | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/3d-filled-line-plots.md
+++ b/unconverted/python/3d-filled-line-plots.md
@@ -22,7 +22,7 @@ jupyter:
     order: 5
     permalink: python/3d-filled-line-plots/
     thumbnail: thumbnail/3d-filled-line-plot.jpg
-    title: 3D Filled Line Plots in Python | plotly
+    
 ---
 
 <!-- #region {"deletable": true, "editable": true} -->

--- a/unconverted/python/3d-network-graph.md
+++ b/unconverted/python/3d-network-graph.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/3d-network-graph/
     thumbnail: thumbnail/3dnetwork.jpg
-    title: 3D Network Graphs in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/3d-parametric-plots.md
+++ b/unconverted/python/3d-parametric-plots.md
@@ -22,7 +22,7 @@ jupyter:
     order: 9
     permalink: python/3d-parametric-plots/
     thumbnail: thumbnail/parametric.jpg
-    title: 3D Parametric Plots in Python | plotly
+    
 ---
 
 <!-- #region {"deletable": true, "editable": true} -->

--- a/unconverted/python/3d-point-clustering.md
+++ b/unconverted/python/3d-point-clustering.md
@@ -22,7 +22,7 @@ jupyter:
     order: 14
     permalink: python/3d-point-clustering/
     thumbnail: thumbnail/3d-clusters.jpg
-    title: 3D Point Clustering in Python | plotly
+    
 ---
 
 <!-- #region {"deletable": true, "editable": true} -->

--- a/unconverted/python/3d-wireframe-plots.md
+++ b/unconverted/python/3d-wireframe-plots.md
@@ -22,7 +22,7 @@ jupyter:
     order: 8
     permalink: python/3d-wireframe-plots/
     thumbnail: thumbnail/wireframe.jpg
-    title: 3D Wireframe Plots in Python | plotly
+    
 ---
 
 <!-- #region {"deletable": true, "editable": true} -->

--- a/unconverted/python/LaTeX.md
+++ b/unconverted/python/LaTeX.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/LaTeX/
     thumbnail: thumbnail/latex.jpg
-    title: Python LaTeX | Examples | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/amazon-redshift.md
+++ b/unconverted/python/amazon-redshift.md
@@ -24,7 +24,7 @@ jupyter:
     permalink: python/amazon-redshift/
     redirect_from: ipython-notebooks/amazon-redshift/
     thumbnail: /images/static-image
-    title: Plot Data from Amazon Redshift | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/anova.md
+++ b/unconverted/python/anova.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/anova/
     thumbnail: /images/static-image
-    title: Anova in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/apache-spark.md
+++ b/unconverted/python/apache-spark.md
@@ -23,7 +23,7 @@ jupyter:
     permalink: python/apache-spark/
     redirect_from: ipython-notebooks/apache-spark/
     thumbnail: /images/static-image
-    title: Plotting Spark DataFrames | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/average_multiple_curves.md
+++ b/unconverted/python/average_multiple_curves.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/average_multiple_curves/
     thumbnail: /images/static-image
-    title: Average Multiple Curves in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/baseline-detection.md
+++ b/unconverted/python/baseline-detection.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/baseline-detection/
     thumbnail: /images/static-image
-    title: Baseline Detection in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/baseline-subtraction.md
+++ b/unconverted/python/baseline-subtraction.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/baseline-subtraction/
     thumbnail: /images/static-image
-    title: Baseline Subtraction in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/basic-statistics.md
+++ b/unconverted/python/basic-statistics.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/basic-statistics/
     thumbnail: /images/static-image
-    title: Basic Statistics in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/big-data-analytics-with-pandas-and-sqlite.md
+++ b/unconverted/python/big-data-analytics-with-pandas-and-sqlite.md
@@ -25,7 +25,7 @@ jupyter:
     permalink: python/big-data-analytics-with-pandas-and-sqlite/
     redirect_from: ipython-notebooks/big-data-analytics-with-pandas-and-sqlite/
     thumbnail: /images/static-image
-    title: Big Data Workflow with Pandas and SQLite | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/cars-exploration.md
+++ b/unconverted/python/cars-exploration.md
@@ -22,7 +22,7 @@ jupyter:
     order: 26
     permalink: python/cars-exploration/
     thumbnail: thumbnail/figurewidget-cars.gif
-    title: Car Exploration with Hover Events
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/change-callbacks-datashader.md
+++ b/unconverted/python/change-callbacks-datashader.md
@@ -22,7 +22,7 @@ jupyter:
     order: 24
     permalink: python/change-callbacks-datashader/
     thumbnail: thumbnail/figurewidget-datashader.gif
-    title: DataShader Case Study
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/chord-diagram.md
+++ b/unconverted/python/chord-diagram.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: u-guide
     permalink: python/chord-diagram/
     thumbnail: thumbnail/chord.jpg
-    title: Chord Diagram | Plotly
+    
 ---
 
 # Chord Diagrams with Plotly

--- a/unconverted/python/cmocean-colorscales.md
+++ b/unconverted/python/cmocean-colorscales.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/cmocean-colorscales/
     thumbnail: thumbnail/colorbars.jpg
-    title: Cmocean Colorscales | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/continuous-error-bars.md
+++ b/unconverted/python/continuous-error-bars.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/continuous-error-bars/
     thumbnail: thumbnail/error-cont.jpg
-    title: Continuous Error Bars | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/convolution.md
+++ b/unconverted/python/convolution.md
@@ -22,7 +22,7 @@ jupyter:
     page_type: example_index
     permalink: python/convolution/
     thumbnail: /images/static-image
-    title: Convolution in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/create-online-dashboard-legacy.md
+++ b/unconverted/python/create-online-dashboard-legacy.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/create-online-dashboard-legacy/
     thumbnail: thumbnail/dashboard.jpg
-    title: Dashboard API | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/density-plots.md
+++ b/unconverted/python/density-plots.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: u-guide
     permalink: python/density-plots/
     thumbnail: thumbnail/density.gif
-    title: Python 2d Density Plots | plotly
+    
 ---
 
 <!-- #region {"deletable": true, "editable": true} -->

--- a/unconverted/python/discrete-frequency.md
+++ b/unconverted/python/discrete-frequency.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/discrete-frequency/
     thumbnail: /images/static-image
-    title: Discrete Frequency in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/exponential-fits.md
+++ b/unconverted/python/exponential-fits.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/exponential-fits/
     thumbnail: thumbnail/exponential_fit.jpg
-    title: Exponential Fit
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/fft-filters.md
+++ b/unconverted/python/fft-filters.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/fft-filters/
     thumbnail: /images/static-image
-    title: FFT Filters in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/filled-area-animation.md
+++ b/unconverted/python/filled-area-animation.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/filled-area-animation/
     thumbnail: thumbnail/apple_stock_animation.gif
-    title: Filled-Area Animation | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/filled-chord-diagram.md
+++ b/unconverted/python/filled-chord-diagram.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: u-guide
     permalink: python/filled-chord-diagram/
     thumbnail: thumbnail/filled-chord.jpg
-    title: Filled Chord Diagram | Plotly
+    
 ---
 
 # Filled-Chord Diagrams with Plotly

--- a/unconverted/python/frequency-counts.md
+++ b/unconverted/python/frequency-counts.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/frequency-counts/
     thumbnail: /images/static-image
-    title: Frequency Counts in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/gapminder-example.md
+++ b/unconverted/python/gapminder-example.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/gapminder-example/
     thumbnail: thumbnail/gapminder_animation.gif
-    title: Adding Sliders to Animations | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/google_big_query.md
+++ b/unconverted/python/google_big_query.md
@@ -22,7 +22,7 @@ jupyter:
     page_type: example_index
     permalink: python/google_big_query/
     thumbnail: thumbnail/bigquery2.jpg
-    title: Google Big Query | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/graph-data-from-mysql-database-in-python.md
+++ b/unconverted/python/graph-data-from-mysql-database-in-python.md
@@ -22,7 +22,7 @@ jupyter:
     page_type: example_index
     permalink: python/graph-data-from-mysql-database-in-python/
     thumbnail: /images/static-image
-    title: Plot Data from a MySQL Database | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/heatmap-animation.md
+++ b/unconverted/python/heatmap-animation.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/heatmap-animation/
     thumbnail: thumbnail/heatmap_animation.gif
-    title: Heatmap Animation | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/heatmap-webgl.md
+++ b/unconverted/python/heatmap-webgl.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/heatmap-webgl/
     thumbnail: thumbnail/heatmap-webgl.jpg
-    title: Python Heatmaps WebGL | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/html-reports.md
+++ b/unconverted/python/html-reports.md
@@ -22,7 +22,7 @@ jupyter:
     page_type: example_index
     permalink: python/html-reports/
     thumbnail: thumbnail/ipython_10_html_report.jpg
-    title: Python HTML Reports
+    
 ---
 
 ## Generate HTML reports with D3 graphs<br>using Python, Plotly, and Pandas

--- a/unconverted/python/insets.md
+++ b/unconverted/python/insets.md
@@ -22,7 +22,7 @@ jupyter:
     page_type: example_index
     permalink: python/insets/
     thumbnail: thumbnail/insets.jpg
-    title: Inset Plots | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/interact-decorator.md
+++ b/unconverted/python/interact-decorator.md
@@ -22,7 +22,7 @@ jupyter:
     order: 4
     permalink: python/interact-decorator/
     thumbnail: thumbnail/figurewidget-interact.gif
-    title: Use Interact decorator with FigureWidget
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/interpolation-and-extrapolation-in-1d.md
+++ b/unconverted/python/interpolation-and-extrapolation-in-1d.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/interpolation-and-extrapolation-in-1d/
     thumbnail: /images/static-image
-    title: Interpolation and Extrapolation in 1D in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/interpolation-and-extrapolation-in-2d.md
+++ b/unconverted/python/interpolation-and-extrapolation-in-2d.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/interpolation-and-extrapolation-in-2d/
     thumbnail: /images/static-image
-    title: Interpolation and Extrapolation in 2D in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/legacy-polar-chart.md
+++ b/unconverted/python/legacy-polar-chart.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/legacy-polar-chart/
     thumbnail: thumbnail/polar-scatter.jpg
-    title: Python Polar Charts | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/linear-algebra.md
+++ b/unconverted/python/linear-algebra.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/linear-algebra/
     thumbnail: /images/static-image
-    title: Linear Algebra in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/linear-fits.md
+++ b/unconverted/python/linear-fits.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/linear-fits/
     thumbnail: thumbnail/linear_fit.jpg
-    title: Linear Fit
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/linear-gauge-chart.md
+++ b/unconverted/python/linear-gauge-chart.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/linear-gauge-chart/
     thumbnail: thumbnail/linear-gauge.jpg
-    title: Python Linear-Gauge Chart | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/logos.md
+++ b/unconverted/python/logos.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/logos/
     thumbnail: thumbnail/your-tutorial-chart.jpg
-    title: Add Logos to Charts | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/matplotlib-colorscales.md
+++ b/unconverted/python/matplotlib-colorscales.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/matplotlib-colorscales/
     thumbnail: thumbnail/colorbars.jpg
-    title: Python Matplotlib Colorscales | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/normality-test.md
+++ b/unconverted/python/normality-test.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/normality-test/
     thumbnail: /images/static-image
-    title: Normality Tests | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/normalization.md
+++ b/unconverted/python/normalization.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/normalization/
     thumbnail: /images/static-image
-    title: Normalization in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/numerical-differentiation.md
+++ b/unconverted/python/numerical-differentiation.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/numerical-differentiation/
     thumbnail: /images/static-image
-    title: Numerical Differentiation in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/numerical-integration.md
+++ b/unconverted/python/numerical-integration.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/numerical-integration/
     thumbnail: /images/static-image
-    title: Numerical Integration in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/outlier-test.md
+++ b/unconverted/python/outlier-test.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/outlier-test/
     thumbnail: /images/static-image
-    title: Outlier Test in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/peak-fitting.md
+++ b/unconverted/python/peak-fitting.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/peak-fitting/
     thumbnail: /images/static-image
-    title: Peak Fitting in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/peak-integration.md
+++ b/unconverted/python/peak-integration.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/peak-integration/
     thumbnail: /images/static-image
-    title: Peak Integration in Python | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/polygon-area.md
+++ b/unconverted/python/polygon-area.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/polygon-area/
     thumbnail: /images/static-image
-    title: Polygon Area in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/polynomial-fits.md
+++ b/unconverted/python/polynomial-fits.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/polynomial-fits/
     thumbnail: thumbnail/polynomial_fit.jpg
-    title: Polynomial Fit
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/population-pyramid-charts.md
+++ b/unconverted/python/population-pyramid-charts.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/population-pyramid-charts/
     thumbnail: thumbnail/pyramid.jpg
-    title: Population Pyramid Charts | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/ribbon-plots.md
+++ b/unconverted/python/ribbon-plots.md
@@ -22,7 +22,7 @@ jupyter:
     order: 4
     permalink: python/ribbon-plots/
     thumbnail: thumbnail/ribbon-plot.jpg
-    title: Python Ribbon Plots | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/salesforce.md
+++ b/unconverted/python/salesforce.md
@@ -25,7 +25,7 @@ jupyter:
     permalink: python/salesforce/
     redirect_from: ipython-notebooks/salesforce/
     thumbnail: /images/static-image
-    title: Interactive Salesforce Graphing | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/simple-mathematics-operations.md
+++ b/unconverted/python/simple-mathematics-operations.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: example_index
     permalink: python/simple-mathematics-operations/
     thumbnail: /images/static-image
-    title: Simple Mathematics Operations in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/statistics-charts.md
+++ b/unconverted/python/statistics-charts.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/statistics-charts/
     thumbnail: /images/static-image
-    title: Statistics Charts in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/streaming-tutorial.md
+++ b/unconverted/python/streaming-tutorial.md
@@ -22,7 +22,7 @@ jupyter:
     permalink: python/streaming-tutorial/
     redirect_from: python/streaming-line-tutorial/
     thumbnail: /images/static-image
-    title: Plotly Streaming
+    
 ---
 
 ### Streaming Support

--- a/unconverted/python/surface-triangulation.md
+++ b/unconverted/python/surface-triangulation.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: u-guide
     permalink: python/surface-triangulation/
     thumbnail: thumbnail/trisurf.jpg
-    title: Python Surface Triangulation | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/t-test.md
+++ b/unconverted/python/t-test.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/t-test/
     thumbnail: /images/static-image
-    title: T-Test in Python. | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/tesla-supercharging-stations.md
+++ b/unconverted/python/tesla-supercharging-stations.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: u-guide
     permalink: python/tesla-supercharging-stations/
     thumbnail: thumbnail/tesla-stations.jpg
-    title: Tesla Supercharging Stations | Plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/trisurf.md
+++ b/unconverted/python/trisurf.md
@@ -24,7 +24,7 @@ jupyter:
     page_type: u-guide
     permalink: python/trisurf/
     thumbnail: thumbnail/tri-surf2.jpg
-    title: Python Trisurf Plots | plotly
+    
 ---
 
 #### New to Plotly?

--- a/unconverted/python/userguide.md
+++ b/unconverted/python/userguide.md
@@ -19,7 +19,7 @@ jupyter:
     page_type: u-guide
     permalink: python/userguide/
     thumbnail: null
-    title: Getting Started Plotly for Python
+    
 ---
 
 # Plotly for Python User Guide

--- a/unconverted/python/webgl-text-and-annotations.md
+++ b/unconverted/python/webgl-text-and-annotations.md
@@ -23,7 +23,7 @@ jupyter:
     page_type: example_index
     permalink: python/webgl-text-and-annotations/
     thumbnail: thumbnail/webgl-text-and-annotations.jpg
-    title: WebGL Text and Annotations | plotly
+    
 ---
 
 #### New to Plotly?


### PR DESCRIPTION
The purpose of this PR is to remove `title` from the front-matter since now in the `documentation` repo titles are being autogenerated based off of the `name` front-matter. 