### PR TITLE
Update scipy and statsmodels for Binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,8 +3,8 @@ plotly==4.2.0
 jupyter
 notebook
 pandas==0.23.0
-statsmodels==0.9.0
-scipy==1.1.0
+statsmodels==0.10.0
+scipy==1.3.1
 patsy==0.5.1
 numpy==1.16.0
 plotly-geo

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -3,7 +3,7 @@ plotly==4.2.0
 jupyter
 notebook
 pandas==0.23.0
-statsmodels==0.10.0
+statsmodels==0.10.1
 scipy==1.3.1
 patsy==0.5.1
 numpy==1.16.0


### PR DESCRIPTION
Following this PR #153, `scipy` and `statsmodels` for Binder should be updated.

---

Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
