### PR TITLE
document new methods add_shape add_annotation

### DIFF
--- a/python/shapes.md
+++ b/python/shapes.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.6
+      jupytext_version: 1.1.1
   kernelspec:
     display_name: Python 3
     language: python
@@ -33,7 +33,6 @@ jupyter:
     order: 32
     permalink: python/shapes/
     thumbnail: thumbnail/shape.jpg
-    
     v4upgrade: true
 ---
 
@@ -59,8 +58,7 @@ fig.update_xaxes(range=[0, 7])
 fig.update_yaxes(range=[0, 2.5])
 
 # Add shapes
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         # Line Vertical
         go.layout.Shape(
             type="line",
@@ -72,7 +70,8 @@ fig.update_layout(
                 color="RoyalBlue",
                 width=3
             )
-        ),
+))
+fig.add_shape(
         # Line Horizontal
         go.layout.Shape(
             type="line",
@@ -85,7 +84,8 @@ fig.update_layout(
                 width=4,
                 dash="dashdot",
             ),
-        ),
+    ))
+fig.add_shape(
         # Line Diagonal
         go.layout.Shape(
             type="line",
@@ -97,11 +97,9 @@ fig.update_layout(
                 color="MediumPurple",
                 width=4,
                 dash="dot",
-            ),
-        ),
-    ]
-)
-
+            )
+))
+fig.update_shapes(dict(xref='x', yref='y'))
 fig.show()
 ```
 
@@ -126,8 +124,7 @@ fig.update_xaxes(range=[0, 8])
 fig.update_yaxes(range=[0, 2])
 
 # Add shapes
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         # Line reference to the axes
         go.layout.Shape(
             type="line",
@@ -141,7 +138,8 @@ fig.update_layout(
                 color="LightSeaGreen",
                 width=3,
             ),
-        ),
+        ))
+fig.add_shape(
         # Line reference to the plot
         go.layout.Shape(
             type="line",
@@ -156,7 +154,6 @@ fig.update_layout(
                 width=3,
             ),
         ),
-    ]
 )
 
 fig.show()
@@ -169,7 +166,7 @@ import plotly.graph_objects as go
 
 import numpy as np
 
-# Generate date
+# Generate data
 x0 = np.linspace(1, 3, 200)
 y0 = x0 * np.sin(np.power(x0, 2)) + 1
 
@@ -187,47 +184,38 @@ fig.update_layout(
 )
 
 # Add tangent line shapes
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         go.layout.Shape(
             type="line",
             x0=1,
             y0=2.30756,
             x1=1.75,
             y1=2.30756,
-            opacity=0.7,
-            line=dict(
-                color="Crimson",
-                width=2.5,
-            ),
-        ),
+        ))
+fig.add_shape(
         go.layout.Shape(
             type="line",
             x0=2.5,
             y0=3.80796,
             x1=3.05,
             y1=3.80796,
-            opacity=0.7,
-            line=dict(
-                color="Crimson",
-                width=2.5,
-            ),
-        ),
+        ))
+fig.add_shape(
         go.layout.Shape(
             type="line",
             x0=1.90,
             y0=-1.1827,
             x1=2.50,
             y1=-1.1827,
-            opacity=0.7,
-            line=dict(
-                color="Crimson",
-                width=2.5,
-            ),
-        ),
-    ]
-)
-
+        ))
+fig.update_shapes(dict(
+    xref="x",
+    yref="y",
+    opacity=0.7,
+    line=dict(
+        color="Crimson",
+        width=2.5,
+        )))
 fig.show()
 ```
 
@@ -250,8 +238,7 @@ fig.update_xaxes(range=[0, 7], showgrid=False)
 fig.update_yaxes(range=[0, 3.5])
 
 # Add shapes
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         # unfilled Rectangle
         go.layout.Shape(
             type="rect",
@@ -262,7 +249,8 @@ fig.update_layout(
             line=dict(
                 color="RoyalBlue",
             ),
-        ),
+        ))
+fig.add_shape(
         # filled Rectangle
         go.layout.Shape(
             type="rect",
@@ -275,10 +263,8 @@ fig.update_layout(
                 width=2,
             ),
             fillcolor="LightSkyBlue",
-        ),
-    ]
-)
-
+        ))
+fig.update_shapes(dict(xref='x', yref='y'))
 fig.show()
 ```
 
@@ -303,8 +289,7 @@ fig.update_xaxes(range=[0, 4], showgrid=False)
 fig.update_yaxes(range=[0, 4])
 
 # Add shapes
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         # Rectangle reference to the axes
         go.layout.Shape(
             type="rect",
@@ -319,7 +304,8 @@ fig.update_layout(
                 width=3,
             ),
             fillcolor="LightSkyBlue",
-        ),
+        ))
+fig.add_shape(
         # Rectangle reference to the plot
         go.layout.Shape(
             type="rect",
@@ -334,9 +320,7 @@ fig.update_layout(
                 width=3,
             ),
             fillcolor="PaleTurquoise",
-        ),
-    ]
-)
+        ))
 
 fig.show()
 ```
@@ -596,37 +580,32 @@ fig.update_yaxes(
 )
 
 # Add circles
-fig.update_layout(
-    shapes=[
+fig.add_shape(
         go.layout.Shape(
-            opacity=0.3,
-            xref="x",
-            yref="y",
+            type="circle",
             fillcolor="blue",
             x0=0,
             y0=0,
             x1=2,
             y1=2,
-            type="circle",
-            line_color="blue",
-            layer="below"
-        ),
+            line_color="blue"
+        ))
+fig.add_shape(
         go.layout.Shape(
-            opacity=0.3,
-            xref="x",
-            yref="y",
+            type="circle",
             fillcolor="gray",
             x0=1.5,
             y0=0,
             x1=3.5,
             y1=2,
-            type="circle",
-            line_color="gray",
-            layer="below"
-        )
-    ],
-)
-
+            line_color="gray"
+        ))
+fig.update_shapes(dict(
+    opacity=0.3,
+    xref="x",
+    yref="y",
+    layer="below"
+))
 # Update figure dimensions
 fig.update_layout(
     margin=dict(

--- a/python/text-and-annotations.md
+++ b/python/text-and-annotations.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.1'
-      jupytext_version: 1.1.7
+      jupytext_version: 1.1.1
   kernelspec:
     display_name: Python 3
     language: python
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.5
+    version: 3.7.3
   plotly:
     description: How to add text labels and annotations to plots in python.
     display_as: file_settings
@@ -32,7 +32,6 @@ jupyter:
     order: 30
     permalink: python/text-and-annotations/
     thumbnail: thumbnail/text-and-annotations.png
-    
     v4upgrade: true
 ---
 
@@ -115,6 +114,8 @@ fig.show()
 
 ### Simple Annotation
 
+Annotations can be added to a figure using `fig.update_layout(annotations=[...])` or `fig.add_annotation`.
+
 ```python
 import plotly.graph_objects as go
 
@@ -168,33 +169,28 @@ fig.add_trace(go.Scatter(
     y=[0, 4, 5, 1, 2, 2, 3, 4, 2]
 ))
 
-fig.update_layout(
-    showlegend=False,
-    annotations=[
-        go.layout.Annotation(
+fig.add_annotation(
+    go.layout.Annotation(
             x=2,
             y=5,
-            xref="x",
-            yref="y",
-            text="dict Text",
-            showarrow=True,
-            arrowhead=7,
-            ax=0,
-            ay=-40
-        ),
-        go.layout.Annotation(
+            text="dict Text")
+)
+fig.add_annotation(
+    go.layout.Annotation(
             x=4,
             y=4,
+            text="dict Text 2")
+)
+fig.update_annotations(dict(
             xref="x",
             yref="y",
-            text="dict Text 2",
             showarrow=True,
             arrowhead=7,
             ax=0,
             ay=-40
-        )
-    ]
-)
+))
+
+fig.update_layout(showlegend=False)
 
 fig.show()
 ```
@@ -351,37 +347,35 @@ fig.add_trace(go.Scatter(
     y=[0, 4, 5, 1, 2, 2, 3, 4, 2]
 ))
 
-fig.update_layout(
-    showlegend=False,
-    annotations=[
-        go.layout.Annotation(
-            x=2,
-            y=5,
-            xref="x",
-            yref="y",
-            text="max=5",
-            showarrow=True,
-            font=dict(
-                family="Courier New, monospace",
-                size=16,
-                color="#ffffff"
+fig.add_annotation(
+    go.layout.Annotation(
+        x=2,
+        y=5,
+        xref="x",
+        yref="y",
+        text="max=5",
+        showarrow=True,
+        font=dict(
+            family="Courier New, monospace",
+            size=16,
+            color="#ffffff"
             ),
-            align="center",
-            arrowhead=2,
-            arrowsize=1,
-            arrowwidth=2,
-            arrowcolor="#636363",
-            ax=20,
-            ay=-30,
-            bordercolor="#c7c7c7",
-            borderwidth=2,
-            borderpad=4,
-            bgcolor="#ff7f0e",
-            opacity=0.8
+        align="center",
+        arrowhead=2,
+        arrowsize=1,
+        arrowwidth=2,
+        arrowcolor="#636363",
+        ax=20,
+        ay=-30,
+        bordercolor="#c7c7c7",
+        borderwidth=2,
+        borderpad=4,
+        bgcolor="#ff7f0e",
+        opacity=0.8
         )
-    ]
 )
 
+fig.update_layout(showlegend=False)
 fig.show()
 ```
 


### PR DESCRIPTION
I did not replace all `update_layout(annotations=[...])` by `add_annotation` because I feel like sometimes the `update_layout` syntax is nice for adding a bunch of objects (and it always works when you don't know that the `add_*` methods exist) but I'm open to changing all occurrences.