### PR TITLE
[Fix] Fix typo (G.node -> G.nodes)

### DIFF
--- a/python/network-graphs.md
+++ b/python/network-graphs.md
@@ -63,8 +63,8 @@ Add edges as disconnected lines in a single trace and nodes as a scatter trace
 edge_x = []
 edge_y = []
 for edge in G.edges():
-    x0, y0 = G.node[edge[0]]['pos']
-    x1, y1 = G.node[edge[1]]['pos']
+    x0, y0 = G.nodes[edge[0]]['pos']
+    x1, y1 = G.nodes[edge[1]]['pos']
     edge_x.append(x0)
     edge_x.append(x1)
     edge_x.append(None)
@@ -81,7 +81,7 @@ edge_trace = go.Scatter(
 node_x = []
 node_y = []
 for node in G.nodes():
-    x, y = G.node[node]['pos']
+    x, y = G.nodes[node]['pos']
     node_x.append(x)
     node_y.append(y)
 


### PR DESCRIPTION
Fixing typo in Create Edges example code.  
(G.node -> G.nodes)

Doc upgrade checklist:

- [ ] random seed is set if using random data
- [ ] file has been moved from `unconverted/x/y.md` to `x/y.md`
- [ ] old boilerplate at top and bottom of file has been removed
- [ ] Every example is independently runnable and is optimized for short line count
- [ ] no more `plot()` or `iplot()`
- [ ] `graph_objs` has been renamed to `graph_objects`
- [ ] `fig = <something>` call is high up in each example
- [ ] minimal creation of intermediate `trace` objects
- [ ] liberal use of `add_trace` and `update_layout`
- [ ] `fig.show()` at the end of each example
- [ ] `px` example at the top if appropriate
- [ ] minimize usage of hex codes for colors in favour of those in https://github.com/plotly/plotly.py-docs/issues/14
