### PR TITLE
Update Circle CI to check order of posts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,9 @@ jobs:
             echo ${mapbox_token} > python/.mapbox_token
             make -kj8 || make -kj8
             curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/front-matter-ci.py > front-matter-ci.py
+            curl https://raw.githubusercontent.com/plotly/documentation/69c99a624397ed2eaf644afd76f3d42fe1b4015c/check-or-enforce-order.py > check-or-enforce-order.py
             python front-matter-ci.py build/html
+            python check-or-enforce-order.py build/html
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               cd build/html
               git init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             echo ${mapbox_token} > python/.mapbox_token
             make -kj8 || make -kj8
             curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/front-matter-ci.py > front-matter-ci.py
-            curl https://raw.githubusercontent.com/plotly/documentation/69c99a624397ed2eaf644afd76f3d42fe1b4015c/check-or-enforce-order.py > check-or-enforce-order.py
+            curl https://raw.githubusercontent.com/plotly/documentation/964cb968aac8b12cdd358a3be0cfb0b079a33ac3/check-or-enforce-order.py > check-or-enforce-order.py
             python front-matter-ci.py build/html
             python check-or-enforce-order.py python
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/front-matter-ci.py > front-matter-ci.py
             curl https://raw.githubusercontent.com/plotly/documentation/964cb968aac8b12cdd358a3be0cfb0b079a33ac3/check-or-enforce-order.py > check-or-enforce-order.py
             python front-matter-ci.py build/html
-            python check-or-enforce-order.py python
+            python check-or-enforce-order.py build/html
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               cd build/html
               git init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             echo ${mapbox_token} > python/.mapbox_token
             make -kj8 || make -kj8
             curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/front-matter-ci.py > front-matter-ci.py
-            curl https://raw.githubusercontent.com/plotly/documentation/964cb968aac8b12cdd358a3be0cfb0b079a33ac3/check-or-enforce-order.py > check-or-enforce-order.py
+            curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/check-or-enforce-order.py > check-or-enforce-order.py
             python front-matter-ci.py build/html
             python check-or-enforce-order.py build/html
             if [ "${CIRCLE_BRANCH}" == "master" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
             curl https://raw.githubusercontent.com/plotly/documentation/source-design-merge/front-matter-ci.py > front-matter-ci.py
             curl https://raw.githubusercontent.com/plotly/documentation/69c99a624397ed2eaf644afd76f3d42fe1b4015c/check-or-enforce-order.py > check-or-enforce-order.py
             python front-matter-ci.py build/html
-            python check-or-enforce-order.py build/html
+            python check-or-enforce-order.py python
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               cd build/html
               git init


### PR DESCRIPTION
The purpose of this PR is to update the CircleCI `config.yml` so that it fetches the `check-or-enforce-order` script from the `documentation` repo and runs it at build time. 