### PR TITLE
pull example in pie chart

### DIFF
--- a/python/pie-charts.md
+++ b/python/pie-charts.md
@@ -79,6 +79,21 @@ fig = go.Figure(data=[go.Pie(labels=labels, values=values, hole=.3)])
 fig.show()
 ```
 
+### Pulling sectors out from the center
+
+For a "pulled-out" or "exploded" layout of the pie chart, use the `pull` argument. It can be a scalar for pulling all sectors or an array to pull only some of the sectors.
+
+```python
+import plotly.graph_objects as go
+
+labels = ['Oxygen','Hydrogen','Carbon_Dioxide','Nitrogen']
+values = [4500, 2500, 1053, 500]
+
+# pull is given as a fraction of the pie radius
+fig = go.Figure(data=[go.Pie(labels=labels, values=values, pull=[0, 0, 0.2, 0])])
+fig.show()
+```
+
 ### Pie Charts in subplots
 
 ```python


### PR DESCRIPTION
For the example with grouped sectors, I'll do it when `px` examples are added because it will be easier to show it with the `px` function.
