### PR TITLE
Make custom colorscale title example more descriptive

### DIFF
--- a/python/colorscales.md
+++ b/python/colorscales.md
@@ -252,7 +252,9 @@ fig.add_trace(go.Contour(
 fig.show()
 ```
 
-### Custom Colorbar
+### Custom Colorbar Title, Labels, and Ticks
+
+Like axes, you can customize the colorbar ticks, labels, and values with `ticks`, `ticktext`, and `tickvals`.
 
 ```python
 import plotly.graph_objects as go


### PR DESCRIPTION
I was searching how to customize the colorscale ticks and found this example. Having a more descriptive title will make this example easier to find.

cc @Mahdis-z @nicolaskruchten @emmanuelle 